### PR TITLE
Fix: Creates void returns endpoint

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 // default settings for lab test runs.
 //
 // This is overridden if arguments are passed to lab via the command line.

--- a/src/modules/returns/routes.js
+++ b/src/modules/returns/routes.js
@@ -5,8 +5,8 @@ const voidReturnsController = require('./void-returns');
 const Joi = require('joi');
 
 const voidReturns = {
-  method: 'POST',
-  handler: voidReturnsController.postVoidReturns,
+  method: 'PATCH',
+  handler: voidReturnsController.patchVoidReturns,
   path: '/returns/1.0/void-returns',
   config: {
     description: 'For the given licence and valid return ids, marks other returns as void',

--- a/src/modules/returns/routes.js
+++ b/src/modules/returns/routes.js
@@ -1,9 +1,29 @@
 const returnsApi = require('./returns');
 const versionsApi = require('./versions');
 const linesApi = require('./lines');
+const voidReturnsController = require('./void-returns');
+const Joi = require('joi');
+
+const voidReturns = {
+  method: 'POST',
+  handler: voidReturnsController.postVoidReturns,
+  path: '/returns/1.0/void-returns',
+  config: {
+    description: 'For the given licence and valid return ids, marks other returns as void',
+    validate: {
+      payload: {
+        licenceId: Joi.string().required(),
+        licenceType: Joi.string().required(),
+        regime: Joi.string().required(),
+        validReturnIds: Joi.array().items(Joi.string())
+      }
+    }
+  }
+};
 
 module.exports = [
   ...returnsApi.getRoutes(),
   ...versionsApi.getRoutes(),
-  ...linesApi.getRoutes()
+  ...linesApi.getRoutes(),
+  voidReturns
 ];

--- a/src/modules/returns/routes.js
+++ b/src/modules/returns/routes.js
@@ -12,7 +12,7 @@ const voidReturns = {
     description: 'For the given licence and valid return ids, marks other returns as void',
     validate: {
       payload: {
-        licenceId: Joi.string().required(),
+        licenceNumber: Joi.string().required(),
         licenceType: Joi.string().required(),
         regime: Joi.string().required(),
         validReturnIds: Joi.array().items(Joi.string())

--- a/src/modules/returns/void-returns.js
+++ b/src/modules/returns/void-returns.js
@@ -1,0 +1,31 @@
+const { logger } = require('../../logger');
+const { repo } = require('../../modules/returns/returns');
+
+/**
+ * For a given licence number with a list of valid return ids, makes any other
+ * returns ids for the licence id have a status of void.
+ * @param {Object} request The HAPI request containng a valdated payload
+ */
+const postVoidReturns = async request => {
+  const { regime, licenceType, licenceId, validReturnIds } = request.payload;
+  const filter = {
+    regime,
+    licence_type: licenceType,
+    licence_ref: licenceId,
+    source: 'NALD',
+    return_id: {
+      $nin: validReturnIds
+    }
+  };
+
+  try {
+    const result = await repo.update(filter, { status: 'void' });
+    logger.info(`Void returns result for ${licenceId}`, result);
+    return result;
+  } catch (err) {
+    logger.error('Failed to void returns', err);
+    return err;
+  }
+};
+
+exports.postVoidReturns = postVoidReturns;

--- a/src/modules/returns/void-returns.js
+++ b/src/modules/returns/void-returns.js
@@ -6,7 +6,7 @@ const { repo } = require('../../modules/returns/returns');
  * returns ids for the licence id have a status of void.
  * @param {Object} request The HAPI request containng a valdated payload
  */
-const postVoidReturns = async request => {
+const patchVoidReturns = async request => {
   const { regime, licenceType, licenceNumber, validReturnIds } = request.payload;
   const filter = {
     regime,
@@ -27,4 +27,4 @@ const postVoidReturns = async request => {
   }
 };
 
-exports.postVoidReturns = postVoidReturns;
+exports.patchVoidReturns = patchVoidReturns;

--- a/src/modules/returns/void-returns.js
+++ b/src/modules/returns/void-returns.js
@@ -7,12 +7,11 @@ const { repo } = require('../../modules/returns/returns');
  * @param {Object} request The HAPI request containng a valdated payload
  */
 const postVoidReturns = async request => {
-  const { regime, licenceType, licenceId, validReturnIds } = request.payload;
+  const { regime, licenceType, licenceNumber, validReturnIds } = request.payload;
   const filter = {
     regime,
     licence_type: licenceType,
-    licence_ref: licenceId,
-    source: 'NALD',
+    licence_ref: licenceNumber,
     return_id: {
       $nin: validReturnIds
     }
@@ -20,7 +19,7 @@ const postVoidReturns = async request => {
 
   try {
     const result = await repo.update(filter, { status: 'void' });
-    logger.info(`Void returns result for ${licenceId}`, result);
+    logger.info(`Void returns result for ${licenceNumber}`, result);
     return result;
   } catch (err) {
     logger.error('Failed to void returns', err);

--- a/test/modules/returns/void-returns.js
+++ b/test/modules/returns/void-returns.js
@@ -8,12 +8,12 @@ const { expect } = require('code');
 const voidReturnsController = require('../../../src/modules/returns/void-returns');
 const { repo } = require('../../../src/modules/returns/returns');
 
-const createReturn = (licenceId, returnId) => {
+const createReturn = (licenceNumber, returnId) => {
   const ret = {
     return_id: returnId,
     regime: 'unit-test-regime',
     licence_type: 'unit-test',
-    licence_ref: licenceId,
+    licence_ref: licenceNumber,
     start_date: (new Date()).toISOString(),
     end_date: (new Date()).toISOString(),
     returns_frequency: 'month',
@@ -54,7 +54,7 @@ experiment('returns/voidReturnsController', () => {
 
       const request = {
         payload: {
-          licenceId: 'unit-test-licence-1',
+          licenceNumber: 'unit-test-licence-1',
           licenceType: 'unit-test',
           regime: 'unit-test-regime',
           validReturnIds: [

--- a/test/modules/returns/void-returns.js
+++ b/test/modules/returns/void-returns.js
@@ -40,7 +40,7 @@ const getAllTestReturns = () => {
 };
 
 experiment('returns/voidReturnsController', () => {
-  experiment('.postVoidReturns', () => {
+  experiment('.patchVoidReturns', () => {
     let updatedReturns;
     let result;
 
@@ -64,7 +64,7 @@ experiment('returns/voidReturnsController', () => {
         }
       };
 
-      result = await voidReturnsController.postVoidReturns(request);
+      result = await voidReturnsController.patchVoidReturns(request);
 
       ({ rows: updatedReturns } = await getAllTestReturns());
     });

--- a/test/modules/returns/void-returns.js
+++ b/test/modules/returns/void-returns.js
@@ -1,0 +1,104 @@
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('lab').script();
+const { expect } = require('code');
+const voidReturnsController = require('../../../src/modules/returns/void-returns');
+const { repo } = require('../../../src/modules/returns/returns');
+
+const createReturn = (licenceId, returnId) => {
+  const ret = {
+    return_id: returnId,
+    regime: 'unit-test-regime',
+    licence_type: 'unit-test',
+    licence_ref: licenceId,
+    start_date: (new Date()).toISOString(),
+    end_date: (new Date()).toISOString(),
+    returns_frequency: 'month',
+    status: 'due',
+    created_at: (new Date()).toISOString(),
+    return_requirement: `requirement-${returnId}`,
+    due_date: (new Date()).toISOString(),
+    source: 'NALD'
+  };
+
+  return repo.create(ret);
+};
+
+const deleteAllTestReturns = () => {
+  return repo.delete({
+    regime: 'unit-test-regime'
+  });
+};
+
+const getAllTestReturns = () => {
+  return repo.find({
+    regime: 'unit-test-regime'
+  });
+};
+
+experiment('returns/voidReturnsController', () => {
+  experiment('.postVoidReturns', () => {
+    let updatedReturns;
+    let result;
+
+    beforeEach(async () => {
+      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-1');
+      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-2');
+      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-3');
+      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-4');
+      await createReturn('unit-test-licence-2', 'unit-test-licence-2-v-1');
+      await createReturn('unit-test-licence-2', 'unit-test-licence-2-v-2');
+
+      const request = {
+        payload: {
+          licenceId: 'unit-test-licence-1',
+          licenceType: 'unit-test',
+          regime: 'unit-test-regime',
+          validReturnIds: [
+            'unit-test-licence-1-v-1',
+            'unit-test-licence-1-v-2'
+          ]
+        }
+      };
+
+      result = await voidReturnsController.postVoidReturns(request);
+
+      ({ rows: updatedReturns } = await getAllTestReturns());
+    });
+
+    afterEach(async () => {
+      await deleteAllTestReturns();
+    });
+
+    test('only two rows are affected', async () => {
+      expect(result.rowCount).to.equal(2);
+    });
+
+    test('the valid returns are left as due', async () => {
+      const valid1 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-1');
+      const valid2 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-2');
+
+      expect(valid1.status).to.equal('due');
+      expect(valid2.status).to.equal('due');
+    });
+
+    test('the invalid returns are made void', async () => {
+      const valid1 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-3');
+      const valid2 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-3');
+
+      expect(valid1.status).to.equal('void');
+      expect(valid2.status).to.equal('void');
+    });
+
+    test('the returns for the other licence are left as due', async () => {
+      const valid1 = updatedReturns.find(x => x.return_id === 'unit-test-licence-2-v-1');
+      const valid2 = updatedReturns.find(x => x.return_id === 'unit-test-licence-2-v-2');
+
+      expect(valid1.status).to.equal('due');
+      expect(valid2.status).to.equal('due');
+    });
+  });
+});


### PR DESCRIPTION
As part of an error with the water service, this change adds a new means
of marking returns as void for a given licence