### PR TITLE
Remove default false value for is test flag on returns route schema

### DIFF
--- a/src/modules/returns/returns.js
+++ b/src/modules/returns/returns.js
@@ -29,7 +29,7 @@ const returnsApi = new HAPIRestAPI({
     return_requirement: Joi.string(),
     under_query: Joi.boolean(),
     under_query_comment: Joi.string(),
-    is_test: Joi.boolean().default(false)
+    is_test: Joi.boolean()
   }
 });
 


### PR DESCRIPTION
feat/water-3020
-- default is_test value removed from schema - database default is set to false
when the regression tests submits a returns via the UI it doesn't pass value in the object for is_test so the schema sets it to false and causes problems during the teardown. 