### PR TITLE
Add dependabot.yml config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# See the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  versioning-strategy: lockfile-only
+- package-ecosystem: "github-actions"
+  # Workflow files stored in the default location of `.github/workflows`
+  directory: "/"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
Adding this enables dependabot for the repo. This means we can now automatically get updates for our dependencies.