### PR TITLE
Remove snyk dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "water-abstraction-returns",
       "version": "2.23.0",
-      "license": "ISC",
+      "license": "OGL-UK-3.0",
       "dependencies": {
         "@envage/hapi-pg-rest-api": "^7.0.0",
         "@envage/water-abstraction-helpers": "4.8.0",
@@ -41,11 +41,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-standard": "^5.0.0",
-        "sinon": "^12.0.1",
-        "snyk": "^1.852.0"
-      },
-      "engines": {
-        "node": ">=12.0"
+        "sinon": "^12.0.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7539,18 +7535,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/snyk": {
-      "version": "1.908.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.908.0.tgz",
-      "integrity": "sha512-fti0j50hDdDBwrwVfLGaHN+xCBvktpxDYIqpJ9pk0IMgQrxBM7fum6l5Pim+Jaq7tZASD3S3p+7RL4JWsS3O/A==",
-      "dev": true,
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
@@ -14558,12 +14542,6 @@
           }
         }
       }
-    },
-    "snyk": {
-      "version": "1.908.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.908.0.tgz",
-      "integrity": "sha512-fti0j50hDdDBwrwVfLGaHN+xCBvktpxDYIqpJ9pk0IMgQrxBM7fum6l5Pim+Jaq7tZASD3S3p+7RL4JWsS3O/A==",
-      "dev": true
     },
     "source-map": {
       "version": "0.7.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^5.0.0",
-    "sinon": "^12.0.1",
-    "snyk": "^1.852.0"
+    "sinon": "^12.0.1"
   }
 }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/6

We use [Snyk](https://snyk.io/) in our CI process to prevent us from adding vulnerable dependencies and let us know if anything we do have is an issue.

It looks like the previous team also added the [Snyk package](https://www.npmjs.com/package/snyk) as a dev dependency. However, you only really need that in situations where you can't use the web-based version.

As part of cleaning up the repo, we're getting rid of this dependency.