### PR TITLE
Update to support symlinks in pm2

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -5,11 +5,12 @@
       "ignore_watch": [
         "node_modules"
       ],
-      "script": "index.js",
+      "script": "./index.js",
       "env": {
         "watch": true
       },
       "env_production": {
+        "cwd": "/srv/app/node/water-abstraction-returns",
         "watch": false,
         "instances" : "max",
         "exec_mode" : "cluster"

--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -10,6 +10,7 @@
         "watch": true
       },
       "env_production": {
+        "script": "index.js",
         "cwd": "/srv/app/node/water-abstraction-returns/current",
         "watch": false,
         "instances" : "max",

--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -5,7 +5,7 @@
       "ignore_watch": [
         "node_modules"
       ],
-      "script": "./index.js",
+      "script": "index.js",
       "env": {
         "watch": true
       },

--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -10,7 +10,7 @@
         "watch": true
       },
       "env_production": {
-        "cwd": "/srv/app/node/water-abstraction-returns",
+        "cwd": "/srv/app/node/water-abstraction-returns/current",
         "watch": false,
         "instances" : "max",
         "exec_mode" : "cluster"


### PR DESCRIPTION
We want to follow a [capistrano-like](https://pm2.keymetrics.io/docs/tutorials/capistrano-like-deployments) model for deployments. This means we deploy and build the project in a timestamped release folder and if all goes well, we update the `current/` folder symlink to point to the new release folder.

```text
project_root
|-- current -> releases/20220711_233800
|-- releases
    |-- 20220711_233800
    |-- 20220710_233230
    |-- 20220709_232724
    |-- 20220708_232541
    |-- 20220707_231242
```

The main benefit is it allows you to roll back with nothing more than a symlink to change. However, pm2 is 'sticky'! Depending on where you start it and how the config is set it doesn't forget the original release folder it's running in when subsequent `restart` or `reload` commands are called. We're making changes in our deployment script to handle where it's started from. But according to the following references, we also need to set `cwd` in our `ecosystem.config.json` file,

- [Capistrano like deployments](https://pm2.keymetrics.io/docs/tutorials/capistrano-like-deployments)
- [How to reload/restart pm2 with flighplan and be aware of a symlink directory?](https://stackoverflow.com/a/43731357/6117745)