### PR TITLE
Replace ESLint with StandardJS

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-# node_modules ignored by default
-migrations

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "standard",
-   "rules": {
-        "semi": [2, "always"]
-    }
-}

--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
-const testMode = parseInt(process.env.TEST_MODE) === 1;
-const isAcceptanceTestTarget = ['local', 'dev', 'development', 'test', 'qa', 'preprod'].includes(process.env.NODE_ENV);
+const testMode = parseInt(process.env.TEST_MODE) === 1
+const isAcceptanceTestTarget = ['local', 'dev', 'development', 'test', 'qa', 'preprod'].includes(process.env.NODE_ENV)
 
 module.exports = {
 
@@ -34,4 +34,4 @@ module.exports = {
   },
 
   isAcceptanceTestTarget
-};
+}

--- a/index.js
+++ b/index.js
@@ -1,24 +1,24 @@
 // provides all API services consumed by VML and VML Admin front ends
-require('dotenv').config();
+require('dotenv').config()
 
 // -------------- Require vendor code -----------------
-const Blipp = require('blipp');
-const Good = require('@hapi/good');
-const GoodWinston = require('good-winston');
-const Hapi = require('@hapi/hapi');
-const HapiAuthJwt2 = require('hapi-auth-jwt2');
+const Blipp = require('blipp')
+const Good = require('@hapi/good')
+const GoodWinston = require('good-winston')
+const Hapi = require('@hapi/hapi')
+const HapiAuthJwt2 = require('hapi-auth-jwt2')
 
 // -------------- Require project code -----------------
-const config = require('./config');
-const routes = require('./src/routes.js');
-const db = require('./src/lib/connectors/db');
+const config = require('./config')
+const routes = require('./src/routes.js')
+const db = require('./src/lib/connectors/db')
 
 // Initialise logger
-const { logger } = require('./src/logger');
-const goodWinstonStream = new GoodWinston({ winston: logger });
+const { logger } = require('./src/logger')
+const goodWinstonStream = new GoodWinston({ winston: logger })
 
 // Define server
-const server = Hapi.server(config.server);
+const server = Hapi.server(config.server)
 
 const registerServerPlugins = async (server) => {
   // Third-party plugins
@@ -30,61 +30,61 @@ const registerServerPlugins = async (server) => {
         winston: [goodWinstonStream]
       }
     }
-  });
+  })
   await server.register({
     plugin: Blipp,
     options: config.blipp
-  });
+  })
 
   // JWT token auth
-  await server.register(HapiAuthJwt2);
-};
+  await server.register(HapiAuthJwt2)
+}
 
 const configureServerAuthStrategy = (server) => {
   server.auth.strategy('jwt', 'jwt', {
     ...config.jwt,
     validate: async (decoded) => ({ isValid: !!decoded.id })
-  });
-  server.auth.default('jwt');
-};
+  })
+  server.auth.default('jwt')
+}
 
 const start = async function () {
   try {
-    await registerServerPlugins(server);
-    configureServerAuthStrategy(server);
-    server.route(routes);
+    await registerServerPlugins(server)
+    configureServerAuthStrategy(server)
+    server.route(routes)
 
     if (!module.parent) {
-      await server.start();
-      const name = process.env.SERVICE_NAME;
-      const uri = server.info.uri;
-      server.log('info', `Service ${name} running at: ${uri}`);
+      await server.start()
+      const name = process.env.SERVICE_NAME
+      const uri = server.info.uri
+      server.log('info', `Service ${name} running at: ${uri}`)
     }
   } catch (err) {
-    logger.error(err);
+    logger.error(err)
   }
-};
+}
 
 const processError = message => err => {
-  logger.error(message, err);
-  process.exit(1);
-};
+  logger.error(message, err)
+  process.exit(1)
+}
 
 process
   .on('unhandledRejection', processError('unhandledRejection'))
   .on('uncaughtException', processError('uncaughtException'))
   .on('SIGINT', async () => {
-    logger.info('Stopping returns service');
+    logger.info('Stopping returns service')
 
-    await server.stop();
-    logger.info('1/2: Hapi server stopped');
+    await server.stop()
+    logger.info('1/2: Hapi server stopped')
 
-    await db.pool.end();
-    logger.info('2/2: Connection pool closed');
+    await db.pool.end()
+    logger.info('2/2: Connection pool closed')
 
-    return process.exit(0);
-  });
+    return process.exit(0)
+  })
 
-start();
+start()
 
-module.exports = server;
+module.exports = server

--- a/migrations/20180704111900-status.js
+++ b/migrations/20180704111900-status.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180704111900-status.js
+++ b/migrations/20180704111900-status.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180704111900-status-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180704111900-status-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180704111900-status-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180704111900-status-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180711163823-add-returns-tables.js
+++ b/migrations/20180711163823-add-returns-tables.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180711163823-add-returns-tables.js
+++ b/migrations/20180711163823-add-returns-tables.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180711163823-add-returns-tables-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180711163823-add-returns-tables-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180711163823-add-returns-tables-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180711163823-add-returns-tables-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180801093342-return-received-date.js
+++ b/migrations/20180801093342-return-received-date.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180801093342-return-received-date.js
+++ b/migrations/20180801093342-return-received-date.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180801093342-return-received-date-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180801093342-return-received-date-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180801093342-return-received-date-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180801093342-return-received-date-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180801161112-add-reading-type-field.js
+++ b/migrations/20180801161112-add-reading-type-field.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180801161112-add-reading-type-field.js
+++ b/migrations/20180801161112-add-reading-type-field.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180801161112-add-reading-type-field-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180801161112-add-reading-type-field-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180801161112-add-reading-type-field-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180801161112-add-reading-type-field-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180803080718-add-indexes.js
+++ b/migrations/20180803080718-add-indexes.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180803080718-add-indexes.js
+++ b/migrations/20180803080718-add-indexes.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180803080718-add-indexes-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180803080718-add-indexes-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180803080718-add-indexes-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180803080718-add-indexes-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180904111909-add-user-units.js
+++ b/migrations/20180904111909-add-user-units.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180904111909-add-user-units.js
+++ b/migrations/20180904111909-add-user-units.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180904111909-add-user-units-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180904111909-add-user-units-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180904111909-add-user-units-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180904111909-add-user-units-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180905080446-convert-timestamps-to-dates.js
+++ b/migrations/20180905080446-convert-timestamps-to-dates.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180905080446-convert-timestamps-to-dates.js
+++ b/migrations/20180905080446-convert-timestamps-to-dates.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180905080446-convert-timestamps-to-dates-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180905080446-convert-timestamps-to-dates-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180905080446-convert-timestamps-to-dates-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180905080446-convert-timestamps-to-dates-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180905100156-unique-constraints.js
+++ b/migrations/20180905100156-unique-constraints.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180905100156-unique-constraints.js
+++ b/migrations/20180905100156-unique-constraints.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180905100156-unique-constraints-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180905100156-unique-constraints-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180905100156-unique-constraints-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180905100156-unique-constraints-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180905103047-remove-user-unit-not-null.js
+++ b/migrations/20180905103047-remove-user-unit-not-null.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180905103047-remove-user-unit-not-null.js
+++ b/migrations/20180905103047-remove-user-unit-not-null.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180905103047-remove-user-unit-not-null-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180905103047-remove-user-unit-not-null-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180905103047-remove-user-unit-not-null-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180905103047-remove-user-unit-not-null-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180905121114-current-version.js
+++ b/migrations/20180905121114-current-version.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180905121114-current-version.js
+++ b/migrations/20180905121114-current-version.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180905121114-current-version-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180905121114-current-version-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180905121114-current-version-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180905121114-current-version-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180914103406-enum-statuses.js
+++ b/migrations/20180914103406-enum-statuses.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180914103406-enum-statuses.js
+++ b/migrations/20180914103406-enum-statuses.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180914103406-enum-statuses-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180914103406-enum-statuses-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180914103406-enum-statuses-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180914103406-enum-statuses-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180914105651-enum-periods.js
+++ b/migrations/20180914105651-enum-periods.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180914105651-enum-periods.js
+++ b/migrations/20180914105651-enum-periods.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180914105651-enum-periods-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180914105651-enum-periods-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180914105651-enum-periods-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180914105651-enum-periods-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20181008091346-returns-add-due-date.js
+++ b/migrations/20181008091346-returns-add-due-date.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20181008091346-returns-add-due-date.js
+++ b/migrations/20181008091346-returns-add-due-date.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20181008091346-returns-add-due-date-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20181008091346-returns-add-due-date-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20181008091346-returns-add-due-date-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20181008091346-returns-add-due-date-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20181106110722-under-query.js
+++ b/migrations/20181106110722-under-query.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20181106110722-under-query.js
+++ b/migrations/20181106110722-under-query.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20181106110722-under-query-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20181106110722-under-query-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20181106110722-under-query-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20181106110722-under-query-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20190116104615-add-void-status.js
+++ b/migrations/20190116104615-add-void-status.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20190116104615-add-void-status.js
+++ b/migrations/20190116104615-add-void-status.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190116104615-add-void-status-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190116104615-add-void-status-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190116104615-add-void-status-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190116104615-add-void-status-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20200709143415-add-is-test-flag.js
+++ b/migrations/20200709143415-add-is-test-flag.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20200709143415-add-is-test-flag.js
+++ b/migrations/20200709143415-add-is-test-flag.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20200709143415-add-is-test-flag-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20200709143415-add-is-test-flag-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20200709143415-add-is-test-flag-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20200709143415-add-is-test-flag-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20210312135203-return-cycles.js
+++ b/migrations/20210312135203-return-cycles.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20210312135203-return-cycles.js
+++ b/migrations/20210312135203-return-cycles.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20210312135203-return-cycles-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20210312135203-return-cycles-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20210312135203-return-cycles-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20210312135203-return-cycles-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20210408121328-link-winter-all-year-2021-cycle.js
+++ b/migrations/20210408121328-link-winter-all-year-2021-cycle.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20210408121328-link-winter-all-year-2021-cycle.js
+++ b/migrations/20210408121328-link-winter-all-year-2021-cycle.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20210408121328-link-winter-all-year-2021-cycle-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20210408121328-link-winter-all-year-2021-cycle-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20210408121328-link-winter-all-year-2021-cycle-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20210408121328-link-winter-all-year-2021-cycle-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,13 +35,8 @@
         "@hapi/lab": "^24.5.1",
         "auto-changelog": "^1.16.4",
         "codecov": "^3.8.3",
-        "eslint": "^8.13.0",
-        "eslint-config-standard": "^14.1.1",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^6.0.0",
-        "eslint-plugin-standard": "^5.0.0",
-        "sinon": "^12.0.1"
+        "sinon": "^12.0.1",
+        "standard": "^17.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2415,7 +2410,7 @@
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "node_modules/@types/minimatch": {
@@ -2561,14 +2556,14 @@
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       },
@@ -2608,6 +2603,24 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
       "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -2875,6 +2888,30 @@
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/builtins/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/cache-base": {
@@ -3591,18 +3628,29 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/es-abstract": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
@@ -3614,9 +3662,10 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3770,16 +3819,53 @@
       }
     },
     "node_modules/eslint-config-standard": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
-      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "peerDependencies": {
-        "eslint": ">=6.2.2",
-        "eslint-plugin-import": ">=2.18.0",
-        "eslint-plugin-node": ">=9.1.0",
-        "eslint-plugin-promise": ">=4.2.1",
-        "eslint-plugin-standard": ">=4.0.0"
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-promise": "^6.0.0"
+      }
+    },
+    "node_modules/eslint-config-standard-jsx": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
+      "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peerDependencies": {
+        "eslint": "^8.8.0",
+        "eslint-plugin-react": "^7.28.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -3824,9 +3910,9 @@
       }
     },
     "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^2.0.0",
@@ -3917,51 +4003,47 @@
     "node_modules/eslint-plugin-import/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "node_modules/eslint-plugin-n": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.4.tgz",
+      "integrity": "sha512-tjnVMv2fiXYMnuiIFI8QMtyUFI42SckEEWvi8h68SWGWshfqO6SSCASy24dGMGAiy7NUk6DZt90DM0iNUsmQ5w==",
       "dev": true,
       "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
+        "is-core-module": "^2.9.0",
+        "minimatch": "^3.1.2",
         "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "semver": "^7.3.7"
       },
       "engines": {
-        "node": ">=8.10.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=12.22.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-promise": {
@@ -3976,28 +4058,70 @@
         "eslint": "^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "deprecated": "standard 16.0.0 and eslint-config-standard 16.0.0 no longer require the eslint-plugin-standard package. You can remove it from your dependencies with 'npm rm eslint-plugin-standard'. More info here: https://github.com/standard/standard/issues/1316",
+    "node_modules/eslint-plugin-react": {
+      "version": "7.30.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz",
+      "integrity": "sha512-NbEvI9jtqO46yJA3wcRF9Mo0lF9T/jhdHqhCHXiXtD+Zcb98812wvokjWpU7Q4QH5edo6dmqrukxVvWWXHlsUg==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+      "dependencies": {
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.1",
+        "object.values": "^1.1.5",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
       "peerDependencies": {
-        "eslint": ">=5.0.0"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-scope": {
@@ -4605,7 +4729,7 @@
     "node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "dependencies": {
         "locate-path": "^2.0.0"
@@ -4683,10 +4807,37 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -4706,17 +4857,29 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4825,6 +4988,12 @@
         "moment": "^2.18.1"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
     "node_modules/handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -4914,9 +5083,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5272,6 +5441,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -5318,9 +5493,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -5605,6 +5780,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -5678,6 +5859,19 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
+      "integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/just-extend": {
@@ -5754,10 +5948,35 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/load-json-file": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "parse-json": "^4.0.0",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0",
+        "type-fest": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/load-json-file/node_modules/type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "dependencies": {
         "p-locate": "^2.0.0",
@@ -5835,6 +6054,18 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -6142,6 +6373,15 @@
         "node": "*"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -6221,9 +6461,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6262,6 +6502,50 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.hasown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
+      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6354,7 +6638,7 @@
     "node_modules/p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "dependencies": {
         "p-limit": "^1.1.0"
@@ -6366,7 +6650,7 @@
     "node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6409,6 +6693,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/pascalcase": {
@@ -6641,6 +6938,80 @@
         "node": ">=6"
       }
     },
+    "node_modules/pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pkg-up": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
@@ -6789,6 +7160,17 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -6871,6 +7253,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -6911,6 +7299,23 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -7641,6 +8046,71 @@
         "node": "*"
       }
     },
+    "node_modules/standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-17.0.0.tgz",
+      "integrity": "sha512-GlCM9nzbLUkr+TYR5I2WQoIah4wHA2lMauqbyPLV/oI5gJxqhHzhjl9EG2N0lr/nRqI3KCbCvm/W3smxvLaChA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "eslint": "^8.13.0",
+        "eslint-config-standard": "17.0.0",
+        "eslint-config-standard-jsx": "^11.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.1.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-react": "^7.28.0",
+        "standard-engine": "^15.0.0"
+      },
+      "bin": {
+        "standard": "bin/cmd.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/standard-engine": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.0.0.tgz",
+      "integrity": "sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.6",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7799,27 +8269,48 @@
         "node": ">=8"
       }
     },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.1",
+        "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7839,7 +8330,7 @@
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -8195,14 +8686,14 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -8504,6 +8995,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/xml2js": {
@@ -10613,7 +11113,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "@types/minimatch": {
@@ -10717,14 +11217,14 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
@@ -10749,6 +11249,18 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
       "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -10951,6 +11463,26 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+    },
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "cache-base": {
       "version": "1.0.1",
@@ -11506,18 +12038,29 @@
         "ansi-colors": "^4.1.1"
       }
     },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "es-abstract": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
@@ -11529,9 +12072,10 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       }
     },
     "es-shim-unscopables": {
@@ -11742,9 +12286,16 @@
       }
     },
     "eslint-config-standard": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
-      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-config-standard-jsx": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
+      "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
       "dev": true,
       "requires": {}
     },
@@ -11791,9 +12342,9 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.0.0",
@@ -11859,39 +12410,35 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
     },
-    "eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "eslint-plugin-n": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.4.tgz",
+      "integrity": "sha512-tjnVMv2fiXYMnuiIFI8QMtyUFI42SckEEWvi8h68SWGWshfqO6SSCASy24dGMGAiy7NUk6DZt90DM0iNUsmQ5w==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
+        "is-core-module": "^2.9.0",
+        "minimatch": "^3.1.2",
         "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "semver": "^7.3.7"
       },
       "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
-            "eslint-visitor-keys": "^1.1.0"
+            "lru-cache": "^6.0.0"
           }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
         }
       }
     },
@@ -11902,12 +12449,55 @@
       "dev": true,
       "requires": {}
     },
-    "eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
+    "eslint-plugin-react": {
+      "version": "7.30.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz",
+      "integrity": "sha512-NbEvI9jtqO46yJA3wcRF9Mo0lF9T/jhdHqhCHXiXtD+Zcb98812wvokjWpU7Q4QH5edo6dmqrukxVvWWXHlsUg==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.1",
+        "object.values": "^1.1.5",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.7"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "2.0.0-next.4",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.9.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        }
+      }
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -12294,7 +12884,7 @@
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
@@ -12354,10 +12944,28 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -12371,15 +12979,21 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
+    },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true
     },
     "get-symbol-description": {
       "version": "1.0.0",
@@ -12460,6 +13074,12 @@
         "moment": "^2.18.1"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
     "handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -12527,9 +13147,9 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
     "has-flag": {
@@ -12798,6 +13418,12 @@
         "kind-of": "^6.0.0"
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
     "is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -12829,9 +13455,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -13032,6 +13658,12 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -13091,6 +13723,16 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
+      "integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.2"
       }
     },
     "just-extend": {
@@ -13160,10 +13802,31 @@
         "type-check": "~0.4.0"
       }
     },
+    "load-json-file": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "parse-json": "^4.0.0",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0",
+        "type-fest": "^0.3.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "requires": {
         "p-locate": "^2.0.0",
@@ -13238,6 +13901,15 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -13460,6 +14132,12 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -13522,9 +14200,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
     "object-keys": {
@@ -13551,6 +14229,38 @@
         "define-properties": "^1.1.3",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
+      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "object.pick": {
@@ -13619,7 +14329,7 @@
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
@@ -13628,7 +14338,7 @@
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true
     },
     "packet-reader": {
@@ -13657,6 +14367,16 @@
       "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
       "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
       "dev": true
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -13835,6 +14555,61 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        }
+      }
+    },
     "pkg-up": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
@@ -13940,6 +14715,17 @@
         "winston": "2.x"
       }
     },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -13998,6 +14784,12 @@
         }
       }
     },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -14029,6 +14821,17 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       }
     },
     "regexpp": {
@@ -14577,6 +15380,34 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
+    "standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-17.0.0.tgz",
+      "integrity": "sha512-GlCM9nzbLUkr+TYR5I2WQoIah4wHA2lMauqbyPLV/oI5gJxqhHzhjl9EG2N0lr/nRqI3KCbCvm/W3smxvLaChA==",
+      "dev": true,
+      "requires": {
+        "eslint": "^8.13.0",
+        "eslint-config-standard": "17.0.0",
+        "eslint-config-standard-jsx": "^11.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.1.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-react": "^7.28.0",
+        "standard-engine": "^15.0.0"
+      }
+    },
+    "standard-engine": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.0.0.tgz",
+      "integrity": "sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.6",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -14696,24 +15527,42 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+    "string.prototype.matchall": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.1",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "strip-ansi": {
@@ -14727,7 +15576,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
     "strip-json-comments": {
@@ -15002,14 +15851,14 @@
       "optional": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },
@@ -15260,6 +16109,12 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true
     },
     "xml2js": {
       "version": "0.4.23",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "license": "OGL-UK-3.0",
   "scripts": {
     "test": "lab",
-    "lint": "eslint .",
+    "lint": "standard",
+    "lint:fix": "standard --fix",
     "migrate": "node scripts/create-schema && db-migrate up --verbose",
     "migrate:down": "db-migrate down --verbose",
     "migrate:create": "db-migrate create --sql-file --"
@@ -44,12 +45,7 @@
     "@hapi/lab": "^24.5.1",
     "auto-changelog": "^1.16.4",
     "codecov": "^3.8.3",
-    "eslint": "^8.13.0",
-    "eslint-config-standard": "^14.1.1",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^6.0.0",
-    "eslint-plugin-standard": "^5.0.0",
-    "sinon": "^12.0.1"
+    "sinon": "^12.0.1",
+    "standard": "^17.0.0"
   }
 }

--- a/scripts/create-schema.js
+++ b/scripts/create-schema.js
@@ -1,10 +1,10 @@
-require('dotenv').config();
-const { pool } = require('../src/lib/connectors/db');
+require('dotenv').config()
+const { pool } = require('../src/lib/connectors/db')
 
 async function run () {
-  const { error } = await pool.query('CREATE SCHEMA IF NOT EXISTS returns;');
-  console.log(error || 'OK');
-  process.exit(error ? 1 : 0);
+  const { error } = await pool.query('CREATE SCHEMA IF NOT EXISTS returns;')
+  console.log(error || 'OK')
+  process.exit(error ? 1 : 0)
 }
 
-run();
+run()

--- a/src/lib/camel-case-keys.js
+++ b/src/lib/camel-case-keys.js
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-const { camelCase } = require('lodash');
-const deepMapKeys = require('map-keys-deep-lodash');
+const { camelCase } = require('lodash')
+const deepMapKeys = require('map-keys-deep-lodash')
 
 /**
  * Camel cases the keys of an object, or an array of objects.
@@ -9,6 +9,6 @@ const deepMapKeys = require('map-keys-deep-lodash');
  * have it's keys camel cased
  */
 const camelCaseKeys = data =>
-  deepMapKeys(data, (value, key) => camelCase(key));
+  deepMapKeys(data, (value, key) => camelCase(key))
 
-module.exports = camelCaseKeys;
+module.exports = camelCaseKeys

--- a/src/lib/connectors/db.js
+++ b/src/lib/connectors/db.js
@@ -1,15 +1,15 @@
 
-require('dotenv').config();
-const pg = require('pg');
-const moment = require('moment');
-const helpers = require('@envage/water-abstraction-helpers');
+require('dotenv').config()
+const pg = require('pg')
+const moment = require('moment')
+const helpers = require('@envage/water-abstraction-helpers')
 
-const config = require('../../../config.js');
-const { logger } = require('../../logger');
+const config = require('../../../config.js')
+const { logger } = require('../../logger')
 
 // Set dates to format YYYY-MM-DD rather than full date/time string with timezone
 pg.types.setTypeParser(1082, 'text', function (val) {
-  return moment(val).format('YYYY-MM-DD');
-});
+  return moment(val).format('YYYY-MM-DD')
+})
 
-exports.pool = helpers.db.createPool(config.pg, logger);
+exports.pool = helpers.db.createPool(config.pg, logger)

--- a/src/lib/connectors/status.js
+++ b/src/lib/connectors/status.js
@@ -1,18 +1,18 @@
-require('dotenv').config();
-const { pool } = require('./db');
-const pkg = require('../../../package.json');
+require('dotenv').config()
+const { pool } = require('./db')
+const pkg = require('../../../package.json')
 
 const getStatus = async () => {
   try {
-    const { rows: data } = await pool.query('select hello from returns.status;');
+    const { rows: data } = await pool.query('select hello from returns.status;')
     return {
       data,
       error: null,
       version: pkg.version
-    };
+    }
   } catch (error) {
-    return { error };
+    return { error }
   }
-};
+}
 
-exports.getStatus = getStatus;
+exports.getStatus = getStatus

--- a/src/lib/repo/queries/return-cycles.js
+++ b/src/lib/repo/queries/return-cycles.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 exports.returnCycleStatsReport = `
 select 
@@ -44,7 +44,7 @@ from (
    where rc.start_date>=$1 and rc.end_date < now()
 ) r
 group by r.return_cycle_id, r.start_date, r.end_date, r.due_date, r.is_summer
-`;
+`
 
 exports.upsert = `
 insert into returns.return_cycles (
@@ -58,11 +58,11 @@ values (
 on conflict (start_date, end_date, is_summer)
   do update set date_updated=now()
   returning *;
-`;
+`
 
 exports.getReturnCycle = `
 select * from returns.return_cycles where return_cycle_id=$1
-`;
+`
 
 exports.getReturnCycleReturns = `
 select 
@@ -84,4 +84,4 @@ left join (
   where v.current=true
 ) v on r.return_id=v.return_id
 where r.return_cycle_id=$1
-`;
+`

--- a/src/lib/repo/return-cycles.js
+++ b/src/lib/repo/return-cycles.js
@@ -1,13 +1,13 @@
-'use strict';
+'use strict'
 
-const { pool } = require('../connectors/db');
+const { pool } = require('../connectors/db')
 
-const queries = require('./queries/return-cycles');
+const queries = require('./queries/return-cycles')
 
 const getReturnCycleStatsReport = async startDate => {
-  const { rows } = await pool.query(queries.returnCycleStatsReport, [startDate]);
-  return rows;
-};
+  const { rows } = await pool.query(queries.returnCycleStatsReport, [startDate])
+  return rows
+}
 
 /**
  * Upserts returns.return_cycles to either get or create a return cycle
@@ -26,10 +26,10 @@ const getOrCreateReturnCycle = async cycle => {
     cycle.startDate,
     cycle.endDate,
     cycle.isSummer
-  ];
-  const { rows: [row] } = await pool.query(queries.upsert, params);
-  return row;
-};
+  ]
+  const { rows: [row] } = await pool.query(queries.upsert, params)
+  return row
+}
 
 /**
  * Gets return cycle by ID
@@ -38,9 +38,9 @@ const getOrCreateReturnCycle = async cycle => {
  * @returns {Promise<Object>}
  */
 const getReturnCycle = async id => {
-  const { rows: [row] } = await pool.query(queries.getReturnCycle, [id]);
-  return row;
-};
+  const { rows: [row] } = await pool.query(queries.getReturnCycle, [id])
+  return row
+}
 
 /**
  * Gets a report of returns for a given cycle
@@ -49,11 +49,11 @@ const getReturnCycle = async id => {
  * @returns {Promise<Array>}
  */
 const getReturnCycleReturns = async id => {
-  const { rows } = await pool.query(queries.getReturnCycleReturns, [id]);
-  return rows;
-};
+  const { rows } = await pool.query(queries.getReturnCycleReturns, [id])
+  return rows
+}
 
-exports.getReturnCycleStatsReport = getReturnCycleStatsReport;
-exports.getOrCreateReturnCycle = getOrCreateReturnCycle;
-exports.getReturnCycle = getReturnCycle;
-exports.getReturnCycleReturns = getReturnCycleReturns;
+exports.getReturnCycleStatsReport = getReturnCycleStatsReport
+exports.getOrCreateReturnCycle = getOrCreateReturnCycle
+exports.getReturnCycle = getReturnCycle
+exports.getReturnCycleReturns = getReturnCycleReturns

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,6 @@
-const config = require('../config');
-const { createLogger } = require('@envage/water-abstraction-helpers').logger;
+const config = require('../config')
+const { createLogger } = require('@envage/water-abstraction-helpers').logger
 
-const logger = createLogger(config.logger);
+const logger = createLogger(config.logger)
 
-exports.logger = logger;
+exports.logger = logger

--- a/src/modules/acceptance-tests/controller.js
+++ b/src/modules/acceptance-tests/controller.js
@@ -1,5 +1,5 @@
-const { pool } = require('../../lib/connectors/db');
-const config = require('../../../config');
+const { pool } = require('../../lib/connectors/db')
+const config = require('../../../config')
 
 const deleteLines = () => {
   return pool.query(`
@@ -12,8 +12,8 @@ const deleteLines = () => {
       v.return_id = r.return_id
       and
       r.is_test = true;
-  `);
-};
+  `)
+}
 
 const deleteVersions = () => {
   return pool.query(`
@@ -24,24 +24,24 @@ const deleteVersions = () => {
       v.return_id = r.return_id
       and
        r.is_test = true;
-  `);
-};
+  `)
+}
 
 const deleteReturns = () => {
   return pool.query(`
     delete
     from returns.returns
     where is_test = true;
-  `);
-};
+  `)
+}
 
 const deleteTestData = async (request, h) => {
   if (config.isAcceptanceTestTarget) {
-    await deleteLines();
-    await deleteVersions();
-    await deleteReturns();
+    await deleteLines()
+    await deleteVersions()
+    await deleteReturns()
   }
-  return h.response().code(204);
-};
+  return h.response().code(204)
+}
 
-exports.deleteTestData = deleteTestData;
+exports.deleteTestData = deleteTestData

--- a/src/modules/acceptance-tests/routes.js
+++ b/src/modules/acceptance-tests/routes.js
@@ -1,5 +1,5 @@
-const controller = require('./controller');
-const config = require('../../../config');
+const controller = require('./controller')
+const config = require('../../../config')
 
 const deleteTestData = {
   method: 'DELETE',
@@ -8,12 +8,12 @@ const deleteTestData = {
   config: {
     description: 'Deletes any data created by the acceptance tests setup'
   }
-};
-
-const routes = [];
-
-if (config.isAcceptanceTestTarget) {
-  routes.push(deleteTestData);
 }
 
-module.exports = routes;
+const routes = []
+
+if (config.isAcceptanceTestTarget) {
+  routes.push(deleteTestData)
+}
+
+module.exports = routes

--- a/src/modules/core/controller.js
+++ b/src/modules/core/controller.js
@@ -1,13 +1,13 @@
-const Boom = require('@hapi/boom');
-const statusConnector = require('../../lib/connectors/status');
+const Boom = require('@hapi/boom')
+const statusConnector = require('../../lib/connectors/status')
 
 const getStatus = async () => {
   try {
-    const status = await statusConnector.getStatus();
-    return status;
+    const status = await statusConnector.getStatus()
+    return status
   } catch (e) {
-    throw Boom.badImplementation(e);
+    throw Boom.badImplementation(e)
   }
-};
+}
 
-exports.getStatus = getStatus;
+exports.getStatus = getStatus

--- a/src/modules/core/routes.js
+++ b/src/modules/core/routes.js
@@ -1,4 +1,4 @@
-const controller = require('./controller');
+const controller = require('./controller')
 
 const status = {
   method: 'GET',
@@ -8,6 +8,6 @@ const status = {
     description: 'Checks if the service is alive'
   },
   path: '/status'
-};
+}
 
-module.exports = [status];
+module.exports = [status]

--- a/src/modules/return-cycles/controller.js
+++ b/src/modules/return-cycles/controller.js
@@ -1,48 +1,48 @@
-'use strict';
-const Boom = require('@hapi/boom');
-const repo = require('../../lib/repo/return-cycles');
+'use strict'
+const Boom = require('@hapi/boom')
+const repo = require('../../lib/repo/return-cycles')
 
-const camelCaseKeys = require('../../lib/camel-case-keys');
+const camelCaseKeys = require('../../lib/camel-case-keys')
 
 /**
  * Gets a list of return cycles with stats about returns in each cycle
  */
 const getReturnCyclesReport = async request => {
-  const { startDate } = request.query;
+  const { startDate } = request.query
 
-  const data = await repo.getReturnCycleStatsReport(startDate);
+  const data = await repo.getReturnCycleStatsReport(startDate)
 
   return {
     data: data.map(camelCaseKeys)
-  };
-};
+  }
+}
 
 /**
  * Get a single return cycle by ID
  */
 const getReturnCycle = async request => {
-  const { returnCycleId } = request.params;
+  const { returnCycleId } = request.params
 
-  const returnCycle = await repo.getReturnCycle(returnCycleId);
+  const returnCycle = await repo.getReturnCycle(returnCycleId)
 
   return returnCycle
     ? camelCaseKeys(returnCycle)
-    : Boom.notFound(`Return cycle ${returnCycleId} not found`);
-};
+    : Boom.notFound(`Return cycle ${returnCycleId} not found`)
+}
 
 /**
  * Get a single return cycle's returns by ID
  */
 const getReturnCycleReturns = async request => {
-  const { returnCycleId } = request.params;
+  const { returnCycleId } = request.params
 
-  const returns = await repo.getReturnCycleReturns(returnCycleId);
+  const returns = await repo.getReturnCycleReturns(returnCycleId)
 
   return {
     data: returns.map(camelCaseKeys)
-  };
-};
+  }
+}
 
-exports.getReturnCyclesReport = getReturnCyclesReport;
-exports.getReturnCycle = getReturnCycle;
-exports.getReturnCycleReturns = getReturnCycleReturns;
+exports.getReturnCyclesReport = getReturnCyclesReport
+exports.getReturnCycle = getReturnCycle
+exports.getReturnCycleReturns = getReturnCycleReturns

--- a/src/modules/return-cycles/routes.js
+++ b/src/modules/return-cycles/routes.js
@@ -1,8 +1,8 @@
-'use-strict';
+'use-strict'
 
-const Joi = require('joi');
+const Joi = require('joi')
 
-const controller = require('./controller');
+const controller = require('./controller')
 
 exports.getReturnCyclesReport = {
   path: '/returns/1.0/return-cycles/report',
@@ -16,7 +16,7 @@ exports.getReturnCyclesReport = {
       })
     }
   }
-};
+}
 
 exports.getReturnCycle = {
   path: '/returns/1.0/return-cycles/{returnCycleId}',
@@ -30,7 +30,7 @@ exports.getReturnCycle = {
       })
     }
   }
-};
+}
 
 exports.getReturnCycleReturns = {
   path: '/returns/1.0/return-cycles/{returnCycleId}/returns',
@@ -44,4 +44,4 @@ exports.getReturnCycleReturns = {
       })
     }
   }
-};
+}

--- a/src/modules/returns/lib/pre-insert.js
+++ b/src/modules/returns/lib/pre-insert.js
@@ -1,9 +1,9 @@
-'use strict';
+'use strict'
 
-const { isObject, get } = require('lodash');
-const helpers = require('@envage/water-abstraction-helpers');
+const { isObject, get } = require('lodash')
+const helpers = require('@envage/water-abstraction-helpers')
 
-const returnCycleRepo = require('../../../lib/repo/return-cycles');
+const returnCycleRepo = require('../../../lib/repo/return-cycles')
 
 /**
  * Returns the correct full return cycle given the return start/end dates and season
@@ -16,7 +16,7 @@ const getCycle = (startDate, isSummer) => ({
   startDate: helpers.returns.date.getPeriodStart(startDate, isSummer),
   endDate: helpers.returns.date.getPeriodEnd(startDate, isSummer),
   isSummer
-});
+})
 
 /**
  * The preInsert hook allows the data to be modified prior to insert.
@@ -28,19 +28,19 @@ const getCycle = (startDate, isSummer) => ({
  */
 const preInsert = async data => {
   // Parse isSummer flag from metadata
-  const metadata = isObject(data.metadata) ? data.metadata : JSON.parse(data.metadata);
-  const isSummer = get(metadata, 'isSummer', false);
+  const metadata = isObject(data.metadata) ? data.metadata : JSON.parse(data.metadata)
+  const isSummer = get(metadata, 'isSummer', false)
 
   // Find matching return cycle
-  const cycle = getCycle(data.start_date, isSummer);
+  const cycle = getCycle(data.start_date, isSummer)
 
   // Get/create return cycle for submitted return
-  const result = await returnCycleRepo.getOrCreateReturnCycle(cycle);
+  const result = await returnCycleRepo.getOrCreateReturnCycle(cycle)
 
   return {
     ...data,
     return_cycle_id: get(result, 'return_cycle_id', null)
-  };
-};
+  }
+}
 
-exports.preInsert = preInsert;
+exports.preInsert = preInsert

--- a/src/modules/returns/lines.js
+++ b/src/modules/returns/lines.js
@@ -1,8 +1,8 @@
-const HAPIRestAPI = require('@envage/hapi-pg-rest-api');
-const Joi = require('joi');
-const { pool } = require('../../lib/connectors/db');
+const HAPIRestAPI = require('@envage/hapi-pg-rest-api')
+const Joi = require('joi')
+const { pool } = require('../../lib/connectors/db')
 
-const isoDateRegex = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+const isoDateRegex = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
 
 const linesApi = new HAPIRestAPI({
   table: 'returns.lines',
@@ -26,6 +26,6 @@ const linesApi = new HAPIRestAPI({
     metadata: Joi.string(),
     reading_type: Joi.string().allow('estimated', 'measured', 'assessed', 'derived')
   }
-});
+})
 
-module.exports = linesApi;
+module.exports = linesApi

--- a/src/modules/returns/returns.js
+++ b/src/modules/returns/returns.js
@@ -1,12 +1,12 @@
-'use strict';
+'use strict'
 
-const Joi = require('joi');
-const HAPIRestAPI = require('@envage/hapi-pg-rest-api');
+const Joi = require('joi')
+const HAPIRestAPI = require('@envage/hapi-pg-rest-api')
 
-const { preInsert } = require('./lib/pre-insert');
-const { pool } = require('../../lib/connectors/db');
+const { preInsert } = require('./lib/pre-insert')
+const { pool } = require('../../lib/connectors/db')
 
-const isoDateRegex = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+const isoDateRegex = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
 
 const returnsApi = new HAPIRestAPI({
   table: 'returns.returns',
@@ -36,8 +36,8 @@ const returnsApi = new HAPIRestAPI({
     is_test: Joi.boolean()
   },
   preInsert
-});
+})
 
-module.exports = returnsApi;
+module.exports = returnsApi
 
-module.exports.repo = returnsApi.repo;
+module.exports.repo = returnsApi.repo

--- a/src/modules/returns/routes.js
+++ b/src/modules/returns/routes.js
@@ -1,8 +1,8 @@
-const returnsApi = require('./returns');
-const versionsApi = require('./versions');
-const linesApi = require('./lines');
-const voidReturnsController = require('./void-returns');
-const Joi = require('joi');
+const returnsApi = require('./returns')
+const versionsApi = require('./versions')
+const linesApi = require('./lines')
+const voidReturnsController = require('./void-returns')
+const Joi = require('joi')
 
 const voidReturns = {
   method: 'PATCH',
@@ -19,11 +19,11 @@ const voidReturns = {
       })
     }
   }
-};
+}
 
 module.exports = [
   ...returnsApi.getRoutes(),
   ...versionsApi.getRoutes(),
   ...linesApi.getRoutes(),
   voidReturns
-];
+]

--- a/src/modules/returns/versions.js
+++ b/src/modules/returns/versions.js
@@ -1,6 +1,6 @@
-const HAPIRestAPI = require('@envage/hapi-pg-rest-api');
-const Joi = require('joi');
-const { pool } = require('../../lib/connectors/db');
+const HAPIRestAPI = require('@envage/hapi-pg-rest-api')
+const Joi = require('joi')
+const { pool } = require('../../lib/connectors/db')
 
 const versionsApi = new HAPIRestAPI({
   table: 'returns.versions',
@@ -29,13 +29,13 @@ const versionsApi = new HAPIRestAPI({
         update returns.versions
         set current=false
         where return_id=$1
-        and version_number < $2;`;
+        and version_number < $2;`
 
-      const params = [data.return_id, data.version_number];
-      await pool.query(query, params);
+      const params = [data.return_id, data.version_number]
+      await pool.query(query, params)
     }
-    return data;
+    return data
   }
-});
+})
 
-module.exports = versionsApi;
+module.exports = versionsApi

--- a/src/modules/returns/void-returns.js
+++ b/src/modules/returns/void-returns.js
@@ -1,5 +1,5 @@
-const { logger } = require('../../logger');
-const { repo } = require('../../modules/returns/returns');
+const { logger } = require('../../logger')
+const { repo } = require('../../modules/returns/returns')
 
 /**
  * For a given licence number with a list of valid return ids, makes any other
@@ -7,7 +7,7 @@ const { repo } = require('../../modules/returns/returns');
  * @param {Object} request The HAPI request containng a valdated payload
  */
 const patchVoidReturns = async request => {
-  const { regime, licenceType, licenceNumber, validReturnIds } = request.payload;
+  const { regime, licenceType, licenceNumber, validReturnIds } = request.payload
   const filter = {
     regime,
     licence_type: licenceType,
@@ -15,16 +15,16 @@ const patchVoidReturns = async request => {
     return_id: {
       $nin: validReturnIds
     }
-  };
+  }
 
   try {
-    const result = await repo.update(filter, { status: 'void' });
-    logger.info(`Void returns result for ${licenceNumber}`, result.rowCount);
-    return result;
+    const result = await repo.update(filter, { status: 'void' })
+    logger.info(`Void returns result for ${licenceNumber}`, result.rowCount)
+    return result
   } catch (err) {
-    logger.error('Failed to void returns', err);
-    return err;
+    logger.error('Failed to void returns', err)
+    return err
   }
-};
+}
 
-exports.patchVoidReturns = patchVoidReturns;
+exports.patchVoidReturns = patchVoidReturns

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,11 +1,11 @@
-const coreRoutes = require('./modules/core/routes');
-const returnsRoutes = require('./modules/returns/routes');
-const acceptanceTestRoutes = require('./modules/acceptance-tests/routes');
-const returnCycleRoutes = require('./modules/return-cycles/routes');
+const coreRoutes = require('./modules/core/routes')
+const returnsRoutes = require('./modules/returns/routes')
+const acceptanceTestRoutes = require('./modules/acceptance-tests/routes')
+const returnCycleRoutes = require('./modules/return-cycles/routes')
 
 module.exports = [
   ...coreRoutes,
   ...returnsRoutes,
   ...acceptanceTestRoutes,
   ...Object.values(returnCycleRoutes)
-];
+]

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,6 @@
-'use-strict';
-const Hapi = require('@hapi/hapi');
-const { cloneDeep } = require('lodash');
+'use-strict'
+const Hapi = require('@hapi/hapi')
+const { cloneDeep } = require('lodash')
 
 /**
  * Creates a HAPI server to allow a single route to be
@@ -11,13 +11,13 @@ const { cloneDeep } = require('lodash');
  * @param {Object} route The HAPI route definition
  */
 const createServerForRoute = route => {
-  const server = Hapi.server();
-  const testRoute = cloneDeep(route);
-  testRoute.handler = async () => 'ok';
+  const server = Hapi.server()
+  const testRoute = cloneDeep(route)
+  testRoute.handler = async () => 'ok'
 
-  server.route(testRoute);
+  server.route(testRoute)
 
-  return server;
-};
+  return server
+}
 
-exports.createServerForRoute = createServerForRoute;
+exports.createServerForRoute = createServerForRoute

--- a/test/lib/connectors/status.js
+++ b/test/lib/connectors/status.js
@@ -1,43 +1,43 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
 
-const { expect } = require('@hapi/code');
+const { expect } = require('@hapi/code')
 
-const statusConnector = require('../../../src/lib/connectors/status');
-const { pool } = require('../../../src/lib/connectors/db');
+const statusConnector = require('../../../src/lib/connectors/status')
+const { pool } = require('../../../src/lib/connectors/db')
 
 experiment('lib/connectors/status', () => {
   experiment('.getStatus', () => {
-    let response;
+    let response
 
     beforeEach(async () => {
       sandbox.stub(pool, 'query').resolves({
         rows: [{
           hello: 'world'
         }]
-      });
-      response = await statusConnector.getStatus();
-    });
+      })
+      response = await statusConnector.getStatus()
+    })
 
     afterEach(async () => {
-      sandbox.restore();
-    });
+      sandbox.restore()
+    })
 
     test('includes the response from the database', async () => {
-      expect(response.data).to.equal([{ hello: 'world' }]);
-    });
+      expect(response.data).to.equal([{ hello: 'world' }])
+    })
 
     test('includes the version from the package.json', async () => {
-      expect(response.version).to.match(/\d*\.\d*\.\d*/);
-    });
-  });
-});
+      expect(response.version).to.match(/\d*\.\d*\.\d*/)
+    })
+  })
+})

--- a/test/lib/repo/return-cycles.js
+++ b/test/lib/repo/return-cycles.js
@@ -1,97 +1,97 @@
-'use-strict';
-const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
-const repo = require('../../../src/lib/repo/return-cycles');
-const { pool } = require('../../../src/lib/connectors/db');
-const queries = require('../../../src/lib/repo/queries/return-cycles');
+'use-strict'
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
+const repo = require('../../../src/lib/repo/return-cycles')
+const { pool } = require('../../../src/lib/connectors/db')
+const queries = require('../../../src/lib/repo/queries/return-cycles')
 
-const data = { foo: 'bar' };
+const data = { foo: 'bar' }
 
 experiment('./lib/repo/return-cycles', () => {
-  let result;
+  let result
 
   beforeEach(async => {
-    sandbox.stub(pool, 'query').resolves({ rows: [data], error: null });
-  });
+    sandbox.stub(pool, 'query').resolves({ rows: [data], error: null })
+  })
 
   afterEach(async => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('.getReturnCycleStatsReport', () => {
-    const startDate = '2018-01-01';
+    const startDate = '2018-01-01'
 
     beforeEach(async () => {
-      result = await repo.getReturnCycleStatsReport(startDate);
-    });
+      result = await repo.getReturnCycleStatsReport(startDate)
+    })
 
     test('calls pool.query with correct query and params', async () => {
       expect(pool.query.calledWith(
         queries.returnCycleStatsReport, [startDate]
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('resolves with array', async () => {
-      expect(result).to.be.an.array();
-    });
-  });
+      expect(result).to.be.an.array()
+    })
+  })
 
   experiment('.getOrCreateReturnCycle', () => {
     const cycle = {
       startDate: '2020-01-01',
       endDate: '2020-12-31',
       isSummer: true
-    };
+    }
 
     beforeEach(async () => {
-      result = await repo.getOrCreateReturnCycle(cycle);
-    });
+      result = await repo.getOrCreateReturnCycle(cycle)
+    })
 
     test('calls pool.query with correct query and params', async () => {
       expect(pool.query.calledWith(
         queries.upsert, [cycle.startDate, cycle.endDate, cycle.isSummer]
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('resolves with a single row', async () => {
-      expect(result).to.equal(data);
-    });
-  });
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('.getReturnCycle', () => {
-    const returnCycleId = 'test-id';
+    const returnCycleId = 'test-id'
 
     beforeEach(async () => {
-      result = await repo.getReturnCycle(returnCycleId);
-    });
+      result = await repo.getReturnCycle(returnCycleId)
+    })
 
     test('calls pool.query with correct query and params', async () => {
       expect(pool.query.calledWith(
         queries.getReturnCycle, [returnCycleId]
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('resolves with a single row', async () => {
-      expect(result).to.equal(data);
-    });
-  });
+      expect(result).to.equal(data)
+    })
+  })
 
   experiment('.getReturnCycleReturns', () => {
-    const returnCycleId = 'test-id';
+    const returnCycleId = 'test-id'
 
     beforeEach(async () => {
-      result = await repo.getReturnCycleReturns(returnCycleId);
-    });
+      result = await repo.getReturnCycleReturns(returnCycleId)
+    })
 
     test('calls pool.query with correct query and params', async () => {
       expect(pool.query.calledWith(
         queries.getReturnCycleReturns, [returnCycleId]
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('resolves with an array', async () => {
-      expect(result).to.be.an.array();
-    });
-  });
-});
+      expect(result).to.be.an.array()
+    })
+  })
+})

--- a/test/modules/core/controller.js
+++ b/test/modules/core/controller.js
@@ -1,30 +1,30 @@
-const { experiment, test, afterEach, beforeEach } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { experiment, test, afterEach, beforeEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
 
-const statusConnector = require('../../../src/lib/connectors/status');
-const controller = require('../../../src/modules/core/controller');
+const statusConnector = require('../../../src/lib/connectors/status')
+const controller = require('../../../src/modules/core/controller')
 
 experiment('modules/core/controller', () => {
   experiment('.getStatus', () => {
     beforeEach(async () => {
-      sandbox.stub(statusConnector, 'getStatus').resolves({ test: true });
-    });
+      sandbox.stub(statusConnector, 'getStatus').resolves({ test: true })
+    })
 
     afterEach(async () => {
-      sandbox.restore();
-    });
+      sandbox.restore()
+    })
 
     test('returns the status', async () => {
-      const response = await controller.getStatus();
-      expect(response.test).to.be.true();
-    });
+      const response = await controller.getStatus()
+      expect(response.test).to.be.true()
+    })
 
     test('throw if the status connector errors', async () => {
-      statusConnector.getStatus.rejects();
-      await expect(controller.getStatus()).to.reject();
-    });
-  });
-});
+      statusConnector.getStatus.rejects()
+      await expect(controller.getStatus()).to.reject()
+    })
+  })
+})

--- a/test/modules/core/routes.js
+++ b/test/modules/core/routes.js
@@ -1,13 +1,13 @@
-const { experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const server = require('../../../index');
+const server = require('../../../index')
 
 experiment('/status', () => {
   test('responds with a status code of 200', async () => {
-    const request = { method: 'get', url: '/status' };
-    const response = await server.inject(request);
+    const request = { method: 'get', url: '/status' }
+    const response = await server.inject(request)
 
-    expect(response.statusCode).to.equal(200);
-  });
-});
+    expect(response.statusCode).to.equal(200)
+  })
+})

--- a/test/modules/return-cycles/controller.js
+++ b/test/modules/return-cycles/controller.js
@@ -1,27 +1,27 @@
 
-'use-strict';
+'use-strict'
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
-const controller = require('../../../src/modules/return-cycles/controller');
-const repo = require('../../../src/lib/repo/return-cycles');
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
+const controller = require('../../../src/modules/return-cycles/controller')
+const repo = require('../../../src/lib/repo/return-cycles')
 
 experiment('/modules/return-cycles/controller', () => {
-  let result;
+  let result
 
   const data = {
     cycles: [{
       return_cycle_id: 'test-id'
     }]
-  };
+  }
 
-  const returnCycleId = 'test-id';
-  const startDate = '2017-01-01';
+  const returnCycleId = 'test-id'
+  const startDate = '2017-01-01'
   const request = {
     params: {
       returnCycleId
@@ -29,90 +29,90 @@ experiment('/modules/return-cycles/controller', () => {
     query: {
       startDate
     }
-  };
+  }
 
   beforeEach(async => {
-    sandbox.stub(repo, 'getReturnCycleStatsReport');
-    sandbox.stub(repo, 'getReturnCycle');
-    sandbox.stub(repo, 'getReturnCycleReturns');
-  });
+    sandbox.stub(repo, 'getReturnCycleStatsReport')
+    sandbox.stub(repo, 'getReturnCycle')
+    sandbox.stub(repo, 'getReturnCycleReturns')
+  })
 
   afterEach(async => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('getReturnCyclesReport', () => {
     beforeEach(async () => {
-      repo.getReturnCycleStatsReport.resolves(data.cycles);
-      result = await controller.getReturnCyclesReport(request);
-    });
+      repo.getReturnCycleStatsReport.resolves(data.cycles)
+      result = await controller.getReturnCyclesReport(request)
+    })
 
     test('calls the expected repo method', async () => {
       expect(repo.getReturnCycleStatsReport.calledWith(
         startDate
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('resolves with the data camel-cased in a { data } envelope', async () => {
       expect(result).to.equal({
         data: [{
           returnCycleId
         }]
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('getReturnCycle', () => {
     experiment('when the cycle is found', () => {
       beforeEach(async () => {
-        repo.getReturnCycle.resolves(data.cycles[0]);
-        result = await controller.getReturnCycle(request);
-      });
+        repo.getReturnCycle.resolves(data.cycles[0])
+        result = await controller.getReturnCycle(request)
+      })
 
       test('calls the expected repo method', async () => {
         expect(repo.getReturnCycle.calledWith(
           returnCycleId
-        )).to.be.true();
-      });
+        )).to.be.true()
+      })
 
       test('resolves with the data camel-cased', async () => {
         expect(result).to.equal({
           returnCycleId
-        });
-      });
-    });
+        })
+      })
+    })
 
     experiment('when the cycle is not found', () => {
       beforeEach(async () => {
-        repo.getReturnCycle.resolves(undefined);
-        result = await controller.getReturnCycle(request);
-      });
+        repo.getReturnCycle.resolves(undefined)
+        result = await controller.getReturnCycle(request)
+      })
 
       test('returns a Boom 404', async () => {
-        expect(result.isBoom).to.be.true();
-        expect(result.output.statusCode).to.equal(404);
-      });
-    });
-  });
+        expect(result.isBoom).to.be.true()
+        expect(result.output.statusCode).to.equal(404)
+      })
+    })
+  })
 
   experiment('getReturnCyclesReturns', () => {
     beforeEach(async () => {
-      repo.getReturnCycleReturns.resolves(data.cycles);
-      result = await controller.getReturnCycleReturns(request);
-    });
+      repo.getReturnCycleReturns.resolves(data.cycles)
+      result = await controller.getReturnCycleReturns(request)
+    })
 
     test('calls the expected repo method', async () => {
       expect(repo.getReturnCycleReturns.calledWith(
         returnCycleId
-      )).to.be.true();
-    });
+      )).to.be.true()
+    })
 
     test('resolves with the data camel-cased in a { data } envelope', async () => {
       expect(result).to.equal({
         data: [{
           returnCycleId
         }]
-      });
-    });
-  });
-});
+      })
+    })
+  })
+})

--- a/test/modules/returns/common.js
+++ b/test/modules/returns/common.js
@@ -1,7 +1,7 @@
-const server = require('../../../index');
-const uuid = require('uuid/v4');
+const server = require('../../../index')
+const uuid = require('uuid/v4')
 
-const headers = { Authorization: process.env.JWT_TOKEN };
+const headers = { Authorization: process.env.JWT_TOKEN }
 
 module.exports = {
   returns: {
@@ -27,8 +27,8 @@ module.exports = {
           under_query: true,
           under_query_comment: 'Return was water damaged'
         }
-      };
-      return server.inject(request);
+      }
+      return server.inject(request)
     },
 
     delete: returnId => {
@@ -36,8 +36,8 @@ module.exports = {
         method: 'DELETE',
         url: `/returns/1.0/returns/${returnId}`,
         headers
-      };
-      return server.inject(request);
+      }
+      return server.inject(request)
     }
   },
 
@@ -47,16 +47,16 @@ module.exports = {
         method: 'GET',
         url: `/returns/1.0/versions/${versionId}`,
         headers
-      };
-      return server.inject(request);
+      }
+      return server.inject(request)
     },
     delete: versionId => {
       const request = {
         method: 'DELETE',
         url: `/returns/1.0/versions/${versionId}`,
         headers
-      };
-      return server.inject(request);
+      }
+      return server.inject(request)
     },
     create: (returnId, versionNumber = 1) => {
       const request = {
@@ -73,8 +73,8 @@ module.exports = {
           nil_return: false,
           current: true
         }
-      };
-      return server.inject(request);
+      }
+      return server.inject(request)
     }
   },
 
@@ -83,7 +83,7 @@ module.exports = {
       const metadata = {
         meterManufacturer: 'Super Accurate Meters',
         meterSerialNumber: '00010001'
-      };
+      }
 
       const request = {
         method: 'POST',
@@ -100,9 +100,9 @@ module.exports = {
           time_period: 'day',
           metadata: JSON.stringify(metadata)
         }
-      };
+      }
 
-      return server.inject(request);
+      return server.inject(request)
     },
 
     delete: lineId => {
@@ -110,9 +110,9 @@ module.exports = {
         method: 'DELETE',
         url: `/returns/1.0/lines/${lineId}`,
         headers
-      };
+      }
 
-      return server.inject(request);
+      return server.inject(request)
     }
   }
-};
+}

--- a/test/modules/returns/lib/pre-insert.js
+++ b/test/modules/returns/lib/pre-insert.js
@@ -1,145 +1,145 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { preInsert } = require('../../../../src/modules/returns/lib/pre-insert');
-const returnCycleRepo = require('../../../../src/lib/repo/return-cycles');
-const { expect } = require('@hapi/code');
+const { preInsert } = require('../../../../src/modules/returns/lib/pre-insert')
+const returnCycleRepo = require('../../../../src/lib/repo/return-cycles')
+const { expect } = require('@hapi/code')
 
-const sandbox = require('sinon').createSandbox();
+const sandbox = require('sinon').createSandbox()
 
 const createReturn = (startDate, endDate, isSummer, isStringified = true) => ({
   start_date: startDate,
   end_date: endDate,
   metadata: isStringified ? JSON.stringify({ isSummer }) : { isSummer }
-});
+})
 
 experiment('modules/returns/lib/pre-insert', () => {
-  let result;
+  let result
 
   beforeEach(async () => {
-    sandbox.stub(returnCycleRepo, 'getOrCreateReturnCycle');
-  });
+    sandbox.stub(returnCycleRepo, 'getOrCreateReturnCycle')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('when a return cycle is found or created', () => {
-    const returnCycleId = 'test-id';
+    const returnCycleId = 'test-id'
 
     beforeEach(async () => {
       returnCycleRepo.getOrCreateReturnCycle.resolves({
         return_cycle_id: returnCycleId
-      });
-    });
+      })
+    })
 
     experiment('for a full winter/all year return', () => {
       beforeEach(async () => {
-        const ret = createReturn('2018-04-01', '2019-03-31', false);
-        result = await preInsert(ret);
-      });
+        const ret = createReturn('2018-04-01', '2019-03-31', false)
+        result = await preInsert(ret)
+      })
 
       test('uses correct cycle dates for a full winter/all year return', async () => {
         expect(returnCycleRepo.getOrCreateReturnCycle.calledWith({
           startDate: '2018-04-01',
           endDate: '2019-03-31',
           isSummer: false
-        })).to.be.true();
-      });
+        })).to.be.true()
+      })
 
       test('resolves with the cycle ID', async () => {
-        expect(result.return_cycle_id).to.equal(returnCycleId);
-      });
-    });
+        expect(result.return_cycle_id).to.equal(returnCycleId)
+      })
+    })
 
     experiment('for a full winter/all year return where the metadata is not JSON stringified', () => {
       beforeEach(async () => {
-        const ret = createReturn('2018-04-01', '2019-03-31', false, false);
-        result = await preInsert(ret);
-      });
+        const ret = createReturn('2018-04-01', '2019-03-31', false, false)
+        result = await preInsert(ret)
+      })
 
       test('uses correct cycle dates for a full winter/all year return', async () => {
         expect(returnCycleRepo.getOrCreateReturnCycle.calledWith({
           startDate: '2018-04-01',
           endDate: '2019-03-31',
           isSummer: false
-        })).to.be.true();
-      });
-    });
+        })).to.be.true()
+      })
+    })
 
     experiment('for a partial winter/all year return', () => {
       beforeEach(async () => {
-        const ret = createReturn('2019-02-01', '2019-03-28', false);
-        result = await preInsert(ret);
-      });
+        const ret = createReturn('2019-02-01', '2019-03-28', false)
+        result = await preInsert(ret)
+      })
 
       test('uses correct cycle dates for a full winter/all year return', async () => {
         expect(returnCycleRepo.getOrCreateReturnCycle.calledWith({
           startDate: '2018-04-01',
           endDate: '2019-03-31',
           isSummer: false
-        })).to.be.true();
-      });
+        })).to.be.true()
+      })
 
       test('resolves with the cycle ID', async () => {
-        expect(result.return_cycle_id).to.equal(returnCycleId);
-      });
-    });
+        expect(result.return_cycle_id).to.equal(returnCycleId)
+      })
+    })
 
     experiment('for a full year summer return', () => {
       beforeEach(async () => {
-        const ret = createReturn('2017-11-01', '2018-10-31', true);
-        result = await preInsert(ret);
-      });
+        const ret = createReturn('2017-11-01', '2018-10-31', true)
+        result = await preInsert(ret)
+      })
 
       test('uses correct cycle dates for a full winter/all year return', async () => {
         expect(returnCycleRepo.getOrCreateReturnCycle.calledWith({
           startDate: '2017-11-01',
           endDate: '2018-10-31',
           isSummer: true
-        })).to.be.true();
-      });
+        })).to.be.true()
+      })
 
       test('resolves with the cycle ID', async () => {
-        expect(result.return_cycle_id).to.equal(returnCycleId);
-      });
-    });
+        expect(result.return_cycle_id).to.equal(returnCycleId)
+      })
+    })
 
     experiment('for a partial year summer return', () => {
       beforeEach(async () => {
-        const ret = createReturn('2017-12-12', '2018-09-31', true);
-        result = await preInsert(ret);
-      });
+        const ret = createReturn('2017-12-12', '2018-09-31', true)
+        result = await preInsert(ret)
+      })
 
       test('uses correct cycle dates for a full winter/all year return', async () => {
         expect(returnCycleRepo.getOrCreateReturnCycle.calledWith({
           startDate: '2017-11-01',
           endDate: '2018-10-31',
           isSummer: true
-        })).to.be.true();
-      });
+        })).to.be.true()
+      })
 
       test('resolves with the cycle ID', async () => {
-        expect(result.return_cycle_id).to.equal(returnCycleId);
-      });
-    });
-  });
+        expect(result.return_cycle_id).to.equal(returnCycleId)
+      })
+    })
+  })
 
   experiment('when a return cycle is not found or created', () => {
     beforeEach(async () => {
-      returnCycleRepo.getOrCreateReturnCycle.resolves(undefined);
-      const ret = createReturn('2019-02-01', '2019-03-28', false);
-      result = await preInsert(ret);
-    });
+      returnCycleRepo.getOrCreateReturnCycle.resolves(undefined)
+      const ret = createReturn('2019-02-01', '2019-03-28', false)
+      result = await preInsert(ret)
+    })
 
     test('return cycle ID is null', async () => {
-      expect(result.return_cycle_id).to.be.null();
-    });
-  });
-});
+      expect(result.return_cycle_id).to.be.null()
+    })
+  })
+})

--- a/test/modules/returns/lines.js
+++ b/test/modules/returns/lines.js
@@ -1,49 +1,49 @@
 /**
  * Test creating/fetching a return
  */
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const server = require('../../../index');
+const { expect } = require('@hapi/code')
+const server = require('../../../index')
 
-const { returns, versions, lines } = require('./common');
+const { returns, versions, lines } = require('./common')
 
 experiment('Check versions API', () => {
-  let versionId;
-  let returnId;
-  let lineId;
-  let versionResponse;
-  let returnResponse;
-  let createLineResponse;
-  let deleteLineResponse;
+  let versionId
+  let returnId
+  let lineId
+  let versionResponse
+  let returnResponse
+  let createLineResponse
+  let deleteLineResponse
 
   beforeEach(async () => {
-    returnResponse = await returns.create();
-    returnId = returnResponse.result.data.return_id;
+    returnResponse = await returns.create()
+    returnId = returnResponse.result.data.return_id
 
-    versionResponse = await versions.create(returnId);
-    versionId = versionResponse.result.data.version_id;
+    versionResponse = await versions.create(returnId)
+    versionId = versionResponse.result.data.version_id
 
-    createLineResponse = await lines.create(versionId);
-    lineId = createLineResponse.result.data.line_id;
-  });
+    createLineResponse = await lines.create(versionId)
+    lineId = createLineResponse.result.data.line_id
+  })
 
   afterEach(async () => {
-    deleteLineResponse = await lines.delete(lineId);
-    await versions.delete(versionId);
-    await returns.delete(returnId);
-  });
+    deleteLineResponse = await lines.delete(lineId)
+    await versions.delete(versionId)
+    await returns.delete(returnId)
+  })
 
   test('The lines API should accept a new line', async () => {
-    expect(createLineResponse.statusCode).to.equal(201);
-  });
+    expect(createLineResponse.statusCode).to.equal(201)
+  })
 
   test('The lines API should edit a returns line', async () => {
     const request = {
@@ -56,18 +56,18 @@ experiment('Check versions API', () => {
         substance: 'H2O',
         time_period: 'week'
       }
-    };
+    }
 
-    const res = await server.inject(request);
-    expect(res.statusCode).to.equal(200);
+    const res = await server.inject(request)
+    expect(res.statusCode).to.equal(200)
 
-    const body = JSON.parse(res.payload);
+    const body = JSON.parse(res.payload)
 
-    expect(body.data.substance).to.equal('H2O');
-    expect(body.data.time_period).to.equal('week');
-  });
+    expect(body.data.substance).to.equal('H2O')
+    expect(body.data.time_period).to.equal('week')
+  })
 
   test('The lines API should delete a returns line', async () => {
-    expect(deleteLineResponse.statusCode).to.equal(200);
-  });
-});
+    expect(deleteLineResponse.statusCode).to.equal(200)
+  })
+})

--- a/test/modules/returns/returns.js
+++ b/test/modules/returns/returns.js
@@ -1,34 +1,34 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const server = require('../../../index');
+const { expect } = require('@hapi/code')
+const server = require('../../../index')
 
-const { returns } = require('./common');
+const { returns } = require('./common')
 
 experiment('Check returns API', () => {
-  let returnId;
-  let createReturnResponse;
-  let deleteReturnResponse;
+  let returnId
+  let createReturnResponse
+  let deleteReturnResponse
 
   beforeEach(async () => {
-    createReturnResponse = await returns.create();
-    returnId = createReturnResponse.result.data.return_id;
-  });
+    createReturnResponse = await returns.create()
+    returnId = createReturnResponse.result.data.return_id
+  })
 
   afterEach(async () => {
-    deleteReturnResponse = await returns.delete(returnId);
-  });
+    deleteReturnResponse = await returns.delete(returnId)
+  })
 
   test('The returns API should accept a new return', async () => {
-    expect(createReturnResponse.statusCode).to.equal(201);
-  });
+    expect(createReturnResponse.statusCode).to.equal(201)
+  })
 
   test('The returns API should update a return', async () => {
     const request = {
@@ -41,16 +41,16 @@ experiment('Check returns API', () => {
         metadata: JSON.stringify({ points: ['SP 456 789'] }),
         received_date: '2018-10-01'
       }
-    };
-    const res = await server.inject(request);
-    expect(res.statusCode).to.equal(200);
-  });
+    }
+    const res = await server.inject(request)
+    expect(res.statusCode).to.equal(200)
+  })
 
   test('The returns API should list returns for a particular regime/licence type', async () => {
     const filter = {
       regime: 'water-test',
       licence_type: 'abstraction-test'
-    };
+    }
 
     const request = {
       method: 'GET',
@@ -58,15 +58,15 @@ experiment('Check returns API', () => {
       headers: {
         Authorization: process.env.JWT_TOKEN
       }
-    };
-    const res = await server.inject(request);
-    expect(res.statusCode).to.equal(200);
+    }
+    const res = await server.inject(request)
+    expect(res.statusCode).to.equal(200)
 
-    const body = JSON.parse(res.payload);
+    const body = JSON.parse(res.payload)
 
-    expect(body.data).to.be.an.array();
-    expect(body.error).to.equal(null);
-  });
+    expect(body.data).to.be.an.array()
+    expect(body.error).to.equal(null)
+  })
 
   test('The returns API should update a return to void status', async () => {
     const request = {
@@ -78,14 +78,14 @@ experiment('Check returns API', () => {
       payload: {
         status: 'void'
       }
-    };
-    const res = await server.inject(request);
-    expect(res.statusCode).to.equal(200);
-    const body = JSON.parse(res.payload);
-    expect(body.data.status).to.equal('void');
-  });
+    }
+    const res = await server.inject(request)
+    expect(res.statusCode).to.equal(200)
+    const body = JSON.parse(res.payload)
+    expect(body.data.status).to.equal('void')
+  })
 
   test('a return can be deleted', async () => {
-    expect(deleteReturnResponse.statusCode).to.equal(200);
-  });
-});
+    expect(deleteReturnResponse.statusCode).to.equal(200)
+  })
+})

--- a/test/modules/returns/versions.js
+++ b/test/modules/returns/versions.js
@@ -1,40 +1,40 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
+} = exports.lab = require('@hapi/lab').script()
 
-const { expect } = require('@hapi/code');
-const server = require('../../../index');
+const { expect } = require('@hapi/code')
+const server = require('../../../index')
 
-const { returns, versions } = require('./common');
+const { returns, versions } = require('./common')
 
 experiment('Check versions API', () => {
-  let versionId;
-  let returnId;
-  let createVersionResponse;
-  let deleteVersionResponse;
-  let returnResponse;
+  let versionId
+  let returnId
+  let createVersionResponse
+  let deleteVersionResponse
+  let returnResponse
 
   beforeEach(async () => {
-    returnResponse = await returns.create();
-    returnId = returnResponse.result.data.return_id;
+    returnResponse = await returns.create()
+    returnId = returnResponse.result.data.return_id
 
-    createVersionResponse = await versions.create(returnId);
-    versionId = createVersionResponse.result.data.version_id;
-  });
+    createVersionResponse = await versions.create(returnId)
+    versionId = createVersionResponse.result.data.version_id
+  })
 
   afterEach(async () => {
-    deleteVersionResponse = await versions.delete(versionId);
-    await returns.delete(returnId);
-  });
+    deleteVersionResponse = await versions.delete(versionId)
+    await returns.delete(returnId)
+  })
 
   test('The versions API should accept a new return version', async () => {
-    expect(createVersionResponse.statusCode).to.equal(201);
-  });
+    expect(createVersionResponse.statusCode).to.equal(201)
+  })
 
   test('The versions API should update a version', async () => {
     const request = {
@@ -46,18 +46,18 @@ experiment('Check versions API', () => {
       payload: {
         user_type: 'external'
       }
-    };
-    const res = await server.inject(request);
-    expect(res.statusCode).to.equal(200);
+    }
+    const res = await server.inject(request)
+    expect(res.statusCode).to.equal(200)
 
-    const body = JSON.parse(res.payload);
-    expect(body.data.user_type).to.equal('external');
-  });
+    const body = JSON.parse(res.payload)
+    expect(body.data.user_type).to.equal('external')
+  })
 
   test('The versions API should list versions for a particular return', async () => {
     const filter = {
       return_id: returnId
-    };
+    }
 
     const request = {
       method: 'GET',
@@ -65,39 +65,39 @@ experiment('Check versions API', () => {
       headers: {
         Authorization: process.env.JWT_TOKEN
       }
-    };
-    const res = await server.inject(request);
-    expect(res.statusCode).to.equal(200);
+    }
+    const res = await server.inject(request)
+    expect(res.statusCode).to.equal(200)
 
-    const body = JSON.parse(res.payload);
+    const body = JSON.parse(res.payload)
 
-    expect(body.data).to.be.an.array();
-    expect(body.error).to.equal(null);
-  });
+    expect(body.data).to.be.an.array()
+    expect(body.error).to.equal(null)
+  })
 
   test('The versions API should delete a particular version', async () => {
-    expect(deleteVersionResponse.statusCode).to.equal(200);
-  });
+    expect(deleteVersionResponse.statusCode).to.equal(200)
+  })
 
   experiment('when creating a new version for the same return', () => {
     test('sets current to false for the old version', async () => {
-      const secondVersionResponse = await versions.create(returnId, 2);
-      const secondVersionId = secondVersionResponse.result.data.version_id;
-      await versions.delete(secondVersionId);
+      const secondVersionResponse = await versions.create(returnId, 2)
+      const secondVersionId = secondVersionResponse.result.data.version_id
+      await versions.delete(secondVersionId)
 
       // get the first version which should now have current set to false
-      const firstResponse = await versions.get(versionId);
+      const firstResponse = await versions.get(versionId)
 
-      expect(firstResponse.result.data.current).to.be.false();
-    });
+      expect(firstResponse.result.data.current).to.be.false()
+    })
 
     test('does not set current to false if the same version is saved', async () => {
-      await versions.create(returnId, 1);
+      await versions.create(returnId, 1)
 
       // get the first version which should still have current set to true
-      const firstResponse = await versions.get(versionId);
+      const firstResponse = await versions.get(versionId)
 
-      expect(firstResponse.result.data.current).to.be.true();
-    });
-  });
-});
+      expect(firstResponse.result.data.current).to.be.true()
+    })
+  })
+})

--- a/test/modules/returns/void-returns.js
+++ b/test/modules/returns/void-returns.js
@@ -3,10 +3,10 @@ const {
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const voidReturnsController = require('../../../src/modules/returns/void-returns');
-const { repo } = require('../../../src/modules/returns/returns');
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const voidReturnsController = require('../../../src/modules/returns/void-returns')
+const { repo } = require('../../../src/modules/returns/returns')
 
 const createReturn = (licenceNumber, returnId) => {
   const ret = {
@@ -22,35 +22,35 @@ const createReturn = (licenceNumber, returnId) => {
     return_requirement: `requirement-${returnId}`,
     due_date: (new Date()).toISOString(),
     source: 'NALD'
-  };
+  }
 
-  return repo.create(ret);
-};
+  return repo.create(ret)
+}
 
 const deleteAllTestReturns = () => {
   return repo.delete({
     regime: 'unit-test-regime'
-  });
-};
+  })
+}
 
 const getAllTestReturns = () => {
   return repo.find({
     regime: 'unit-test-regime'
-  });
-};
+  })
+}
 
 experiment('returns/voidReturnsController', () => {
   experiment('.patchVoidReturns', () => {
-    let updatedReturns;
-    let result;
+    let updatedReturns
+    let result
 
     beforeEach(async () => {
-      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-1');
-      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-2');
-      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-3');
-      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-4');
-      await createReturn('unit-test-licence-2', 'unit-test-licence-2-v-1');
-      await createReturn('unit-test-licence-2', 'unit-test-licence-2-v-2');
+      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-1')
+      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-2')
+      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-3')
+      await createReturn('unit-test-licence-1', 'unit-test-licence-1-v-4')
+      await createReturn('unit-test-licence-2', 'unit-test-licence-2-v-1')
+      await createReturn('unit-test-licence-2', 'unit-test-licence-2-v-2')
 
       const request = {
         payload: {
@@ -62,43 +62,43 @@ experiment('returns/voidReturnsController', () => {
             'unit-test-licence-1-v-2'
           ]
         }
-      };
+      }
 
       result = await voidReturnsController.patchVoidReturns(request);
 
-      ({ rows: updatedReturns } = await getAllTestReturns());
-    });
+      ({ rows: updatedReturns } = await getAllTestReturns())
+    })
 
     afterEach(async () => {
-      await deleteAllTestReturns();
-    });
+      await deleteAllTestReturns()
+    })
 
     test('only two rows are affected', async () => {
-      expect(result.rowCount).to.equal(2);
-    });
+      expect(result.rowCount).to.equal(2)
+    })
 
     test('the valid returns are left as due', async () => {
-      const valid1 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-1');
-      const valid2 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-2');
+      const valid1 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-1')
+      const valid2 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-2')
 
-      expect(valid1.status).to.equal('due');
-      expect(valid2.status).to.equal('due');
-    });
+      expect(valid1.status).to.equal('due')
+      expect(valid2.status).to.equal('due')
+    })
 
     test('the invalid returns are made void', async () => {
-      const valid1 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-3');
-      const valid2 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-3');
+      const valid1 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-3')
+      const valid2 = updatedReturns.find(x => x.return_id === 'unit-test-licence-1-v-3')
 
-      expect(valid1.status).to.equal('void');
-      expect(valid2.status).to.equal('void');
-    });
+      expect(valid1.status).to.equal('void')
+      expect(valid2.status).to.equal('void')
+    })
 
     test('the returns for the other licence are left as due', async () => {
-      const valid1 = updatedReturns.find(x => x.return_id === 'unit-test-licence-2-v-1');
-      const valid2 = updatedReturns.find(x => x.return_id === 'unit-test-licence-2-v-2');
+      const valid1 = updatedReturns.find(x => x.return_id === 'unit-test-licence-2-v-1')
+      const valid2 = updatedReturns.find(x => x.return_id === 'unit-test-licence-2-v-2')
 
-      expect(valid1.status).to.equal('due');
-      expect(valid2.status).to.equal('due');
-    });
-  });
-});
+      expect(valid1.status).to.equal('due')
+      expect(valid2.status).to.equal('due')
+    })
+  })
+})


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/9

Defra's JavaScript standard is to use StandardJS for linting. We currently use ESLint, configured to Semi-Standard (ie. StandardJS with semicolons). For consistency, we should change this to the regular Standard rules, and replace ESLint with StandardJS while we're at it.