### PR TITLE
Hide `standard` linting commit with `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,19 @@
+# This file contains a list of commits with mass changes for exclusion by `git blame`.
+#
+# Passing `--ignore-revs-file .git-blame-ignore-revs` as a flag will tell git to "ignore changes made by the revision
+# when assigning blame, as if the change never happened".
+#
+# For example:
+#   git blame --ignore-revs-file .git-blame-ignore-revs ...
+#
+# You can make this the default for your local repo using:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Doing this will allow the GitLens VS Code extension (and other tools which use the output of `git blame`) to make use
+# of the file for the repo.
+#
+# Note that `git blame` does not use any file by default, and  the filename `.git-blame-ignore-revs` is just a
+# convention.
+
+# Replace ESLint with StandardJS (#293)
+affbcb7ce12871887f1e640af65fa251f04c5836


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/37

This change creates a `.git-blame-ignore-revs` file containing the sha of the commit that switched from using ES Lint and semi-standard to plain old JS standard. This will hide this commit in `git blame` (given the correct config option) and in GitHub's blame view.
