### PR TITLE
Correctly set NODE_ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,8 @@ JWT_SECRET=
 ERRBIT_KEY=
 ERRBIT_SERVER=
 
-NODE_ENV=
+NODE_ENV=production
+ENVIRONMENT=pre
 
 # Set log level for app. Default is 'info'
 WRLS_LOG_LEVEL=debug

--- a/config.js
+++ b/config.js
@@ -23,7 +23,7 @@ module.exports = {
 
   pg: {
     connectionString: process.env.DATABASE_URL,
-    max: process.env.NODE_ENV === 'local' ? 20 : 7,
+    max: 7,
     idleTimeoutMillis: 10000,
     connectionTimeoutMillis: 5000
   },

--- a/config.js
+++ b/config.js
@@ -1,4 +1,7 @@
-const isAcceptanceTestTarget = ['local', 'dev', 'development', 'test', 'qa', 'preprod'].includes(process.env.NODE_ENV)
+'use strict'
+
+const environment = process.env.ENVIRONMENT
+const isProduction = environment === 'prd'
 
 module.exports = {
 
@@ -32,5 +35,5 @@ module.exports = {
     }
   },
 
-  isAcceptanceTestTarget
+  isProduction
 }

--- a/src/modules/acceptance-tests/controller.js
+++ b/src/modules/acceptance-tests/controller.js
@@ -36,7 +36,7 @@ const deleteReturns = () => {
 }
 
 const deleteTestData = async (request, h) => {
-  if (config.isAcceptanceTestTarget) {
+  if (!config.isProduction) {
     await deleteLines()
     await deleteVersions()
     await deleteReturns()

--- a/src/modules/acceptance-tests/routes.js
+++ b/src/modules/acceptance-tests/routes.js
@@ -12,7 +12,7 @@ const deleteTestData = {
 
 const routes = []
 
-if (config.isAcceptanceTestTarget) {
+if (!config.isProduction) {
   routes.push(deleteTestData)
 }
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/43

We are currently using `NODE_ENV` incorrectly; we set it to be the name of the specific environment (eg. `local`, `qa` etc.) when it should be more like the _type_ of environment (eg. is it a dev environment, a production environment, etc.)

This means that tools like pm2 aren't correctly picking up that we are running in a dev-like or prod-like environment and configuring accordingly.

We, therefore, change how we use `NODE_ENV` to be the type of environment, with a separate `ENVIRONMENT` env var to set the actual environment (eg. `tst`, `pre` etc.)