### PR TITLE
Make auto-changelog external

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
       "devDependencies": {
         "@hapi/code": "^8.0.7",
         "@hapi/lab": "^24.5.1",
-        "auto-changelog": "^1.16.4",
         "sinon": "^12.0.1",
         "standard": "^17.0.0"
       }
@@ -2435,25 +2434,6 @@
         "node": ">= 4.5.0"
       }
     },
-    "node_modules/auto-changelog": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-1.16.4.tgz",
-      "integrity": "sha512-h7diyELoq692AA4oqO50ULoYKIomUdzuQ+NW+eFPwIX0xzVbXEu9cIcgzZ3TYNVbpkGtcNKh51aRfAQNef7HVA==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^5.0.0",
-        "core-js": "^3.6.4",
-        "handlebars": "^4.7.3",
-        "lodash.uniqby": "^4.7.0",
-        "node-fetch": "^2.6.0",
-        "parse-github-url": "^1.0.2",
-        "regenerator-runtime": "^0.13.5",
-        "semver": "^6.3.0"
-      },
-      "bin": {
-        "auto-changelog": "lib/index.js"
-      }
-    },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2951,15 +2931,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -2993,17 +2964,6 @@
       "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.1.tgz",
-      "integrity": "sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-util-is": {
@@ -5673,12 +5633,6 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
     },
-    "node_modules/lodash.uniqby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
-      "dev": true
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6297,18 +6251,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/parse-github-url": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
-      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
-      "dev": true,
-      "bin": {
-        "parse-github-url": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -6783,12 +6725,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
@@ -11014,22 +10950,6 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
-    "auto-changelog": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-1.16.4.tgz",
-      "integrity": "sha512-h7diyELoq692AA4oqO50ULoYKIomUdzuQ+NW+eFPwIX0xzVbXEu9cIcgzZ3TYNVbpkGtcNKh51aRfAQNef7HVA==",
-      "dev": true,
-      "requires": {
-        "commander": "^5.0.0",
-        "core-js": "^3.6.4",
-        "handlebars": "^4.7.3",
-        "lodash.uniqby": "^4.7.0",
-        "node-fetch": "^2.6.0",
-        "parse-github-url": "^1.0.2",
-        "regenerator-runtime": "^0.13.5",
-        "semver": "^6.3.0"
-      }
-    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -11416,12 +11336,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -11450,12 +11364,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw=="
-    },
-    "core-js": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.1.tgz",
-      "integrity": "sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ==",
-      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -13515,12 +13423,6 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
     },
-    "lodash.uniqby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
-      "dev": true
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -13974,12 +13876,6 @@
         "mongodb-uri": ">= 0.9.7"
       }
     },
-    "parse-github-url": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
-      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
-      "dev": true
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -14334,12 +14230,6 @@
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "migrate": "node scripts/create-schema && db-migrate up --verbose",
     "migrate:down": "db-migrate down --verbose",
     "migrate:create": "db-migrate create --sql-file --",
-    "version": "auto-changelog -p --commit-limit false && git add CHANGELOG.md"
+    "changelog": "npx auto-changelog --yes -p --commit-limit false"
   },
   "dependencies": {
     "@envage/hapi-pg-rest-api": "^7.0.0",
@@ -41,7 +41,6 @@
   "devDependencies": {
     "@hapi/code": "^8.0.7",
     "@hapi/lab": "^24.5.1",
-    "auto-changelog": "^1.16.4",
     "sinon": "^12.0.1",
     "standard": "^17.0.0"
   }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/58

To reduce dependencies and to make the process consistent we are moving auto-changelog out of the project. Instead will use npx to run it directly.