### PR TITLE
Revert changelog script change with improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "migrate": "node scripts/create-schema && db-migrate up --verbose",
     "migrate:down": "db-migrate down --verbose",
     "migrate:create": "db-migrate create --sql-file --",
-    "changelog": "npx --yes auto-changelog -p --commit-limit false"
+    "version": "npx --yes auto-changelog -p --commit-limit false && git add CHANGELOG.md"
   },
   "dependencies": {
     "@envage/hapi-pg-rest-api": "^7.0.0",


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/59

We realised that the previous name for the script was intentional. It was so that it would be automatically kicked off when `npm version` was called from the command line.

Using `npm version` not only means the `package-lock.json` gets updated as well, but it also generates the correct tag for us. Finally, we can just decide the change type (major, minor or patch) and let npm work out the bump. This means we're less likely to make a mistake.

So now our process when generating a new release will be

- decide on the change type
- run `npm version [major|minor|patch]`
- check the changes
- push the commit

Much simpler as we don't need to be specific with version numbers.