### PR TITLE
Stop passing err to logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,12 +61,12 @@ const start = async function () {
       server.log('info', `Service ${name} running at: ${uri}`)
     }
   } catch (err) {
-    logger.error(err)
+    logger.error(err.stack)
   }
 }
 
 const processError = message => err => {
-  logger.error(message, err)
+  logger.error(message, err.stack)
   process.exit(1)
 }
 

--- a/src/modules/returns/void-returns.js
+++ b/src/modules/returns/void-returns.js
@@ -22,7 +22,7 @@ const patchVoidReturns = async request => {
     logger.info(`Void returns result for ${licenceNumber}`, result.rowCount)
     return result
   } catch (err) {
-    logger.error('Failed to void returns', err)
+    logger.error('Failed to void returns', err.stack)
     return err
   }
 }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/45

Here we are trying to make the error logs more usable. Currently when an error happens the logs are getting jammed up with thousands of lines making them difficult to read and unusable. This change stops that pollution making them more usable.