### PR TITLE
Remove pm2 watch config from ecosystem file

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -2,15 +2,8 @@
   "apps": [
     {
       "name": "returns",
-      "ignore_watch": [
-        "node_modules"
-      ],
       "script": "index.js",
-      "env": {
-        "watch": true
-      },
       "env_production": {
-        "watch": false,
         "instances" : "max",
         "exec_mode" : "cluster"
       }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/10

Here we have removed the watch config for pm2. This is due to using nodemon instead. Having both in the application is causing too many files to be registered, making it problematic to watch.