### PR TITLE
Only log errors

### DIFF
--- a/src/plugins/hapi-pino.plugin.js
+++ b/src/plugins/hapi-pino.plugin.js
@@ -31,11 +31,14 @@ const config = require('../../config.js')
  */
 const testOptions = () => {
   if (process.env.NODE_ENV !== 'test' || config.log.logInTest) {
-    return {}
+    return {
+      // Only log errored requests
+      logEvents: ['request-error']
+    }
   }
 
   return {
-    // Don't log requests etc
+    // Don't log requests at all
     logEvents: false,
     // Don't log anything tagged with DEBUG or info, for example, req.log(['INFO'], 'User is an admin')
     ignoredEventTags: { log: ['DEBUG', 'INFO'], request: ['DEBUG', 'INFO'] }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/79

We have an ongoing problem where the log files for our apps very quickly become massive. In the space of a week, we can see a repo like [water-abstraction-returns](https://github.com/DEFRA/water-abstraction-returns) generate a log file almost 10Gb in size!

Fortunately, we have a solution in place for `production` that truncates them on a regular basis. But because we switch off our non-prod environments that process is often blocked there, meaning the logs get out of hand and use up all available disk space. It also means our local environments can be extremely noisy and if we don't switch them off, they too can run into the same issue.

So, for our background web services, we are moving to only logging errors in the hope this reduces the size of our logs. The change only applies to what [hapi-pino](https://github.com/pinojs/hapi-pino) is doing. So, any logging we do within the app code will still be emitted. But when a service like **water-abstraction-returns**, gets hammered with requests we'll be removing a lot of unnecessary output.