### PR TITLE
Only log errors - tweak!

### DIFF
--- a/config.js
+++ b/config.js
@@ -19,13 +19,14 @@ module.exports = {
   log: {
     // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
     // converting the env var to a boolean
-    logInTest: (String(process.env.LOG_IN_TEST) === 'true') || false
+    logInTest: (String(process.env.LOG_IN_TEST) === 'true') || false,
+    level: process.env.WRLS_LOG_LEVEL || 'warn'
   },
 
   // This config is used by water-abstraction-helpers and its use of Winston and Airbrake. Any use of `logger.info()`,
   // for example, is built on this config.
   logger: {
-    level: process.env.WRLS_LOG_LEVEL || 'info',
+    level: process.env.WRLS_LOG_LEVEL || 'warn',
     airbrakeKey: process.env.ERRBIT_KEY,
     airbrakeHost: process.env.ERRBIT_SERVER,
     airbrakeLevel: 'error'

--- a/src/plugins/hapi-pino.plugin.js
+++ b/src/plugins/hapi-pino.plugin.js
@@ -32,8 +32,7 @@ const config = require('../../config.js')
 const testOptions = () => {
   if (process.env.NODE_ENV !== 'test' || config.log.logInTest) {
     return {
-      // Only log errored requests
-      logEvents: ['request-error']
+      level: config.log.level
     }
   }
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/79

In [Only log errors](https://github.com/DEFRA/water-abstraction-returns/pull/337) we made a change to our [Hapi-pino](https://github.com/pinojs/hapi-pino) config so that we only log request errors.

We assumed that would cover `4xx` and `5xx` responses but it turns out that is not the case. It only covers when an error is thrown or when we return a [Boom error](https://hapi.dev/module/boom/). We still need to be able to track when we get `4xx` errors as it will tell us that a request might be malformed leading to a `404`, a `409` or a `401`.

But we only need this info in **production**. We can keep things as is because it has a handle on our _massive_ logs. But we can live without the info in our non-prod environments.

So, we make a tweak to use [hapi-pino's level option](https://github.com/pinojs/hapi-pino#optionslevel-pinolevel) instead and base it on an existing env var. That way we can leave **production** as is but quiet things down in **non-production** with the option of logging again when needed.