### PR TITLE
Stop using version in package.json

### DIFF
--- a/src/modules/health/controller.js
+++ b/src/modules/health/controller.js
@@ -4,7 +4,14 @@
 const util = require('util')
 const exec = util.promisify(require('child_process').exec)
 
-const pkg = require('../../../package.json')
+const _tagReference = async () => {
+  try {
+    const { stdout, stderr } = await exec('git describe --always --tags')
+    return stderr ? `ERROR: ${stderr}` : stdout.replace('\n', '')
+  } catch (error) {
+    return `ERROR: ${error.message}`
+  }
+}
 
 const _getCommitHash = async () => {
   try {
@@ -17,7 +24,7 @@ const _getCommitHash = async () => {
 
 const getInfo = async () => {
   return {
-    version: pkg.version,
+    version: await _tagReference(),
     commit: await _getCommitHash()
   }
 }

--- a/test/modules/health/controller.test.js
+++ b/test/modules/health/controller.test.js
@@ -4,9 +4,6 @@
 const { test, experiment, before } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
 
-// Test helpers
-const pkg = require('../../../package.json')
-
 // Thing under test
 const controller = require('../../../src/modules/health/controller')
 
@@ -19,7 +16,7 @@ experiment('modules/health/controller', () => {
     })
 
     test('contains the expected water service version', async () => {
-      expect(info.version).to.equal(pkg.version)
+      expect(info.version).to.exist()
     })
 
     test('contains the git commit hash', async () => {


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/107

Currently, we have each app report details about itself on a `/health/info` endpoint. For each app this returns the current commit hash and the version recorded in `package.json`.

All this then gets shown in our main `/service-status` endpoint (or `/health/info` in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) if you want to go direct!)

Normally, when we cut a release we're ok to just take whatever is on `main` and tag that as the next version. We run `npm version [minor|patch]` and both the tagging and the updating of the version in `package.json` is done for us.

But in a recent release `main` in a couple of the repos contained changes we weren't yet ready to include. No problem, we just have to check out an earlier commit and create the [git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) there. This does mean though we can't run `npm version` and increment the version in `package.json`.

The issue came when our QA went to `/service-status` to double-check the versions now running. The commit hashes were all correct; we were running the version of the code we'd tagged for release. But the versions displayed were now out of sync with the git tags.

There are only 3 solutions as far as we can see

- wait until everything's been tested - just not practical
- go back to using git-flow and development/release branches - not on your life!
- stop using the version in `package.json` - 👈 😁

Whenever we 'cut' a release we create a tag at the commit we intend to push to production. The tag is our version, not what's in the `package.json`. So, if all our `/health/info` endpoints returned the result of `git describe --always --tags` instead they would be

- more accurate
- avoid this confusion