### PR TITLE
Update `water-abstraction-helpers` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@envage/hapi-pg-rest-api": "^7.0.0",
-        "@envage/water-abstraction-helpers": "4.8.3",
+        "@envage/water-abstraction-helpers": "^4.9.0",
         "@hapi/boom": "^9.1.4",
         "@hapi/hapi": "^21.3.2",
         "blipp": "^4.0.2",
@@ -399,18 +399,18 @@
       }
     },
     "node_modules/@envage/water-abstraction-helpers": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-4.8.3.tgz",
-      "integrity": "sha512-p/pemY1kKT7DPxr7iXY/o/kjvAIWyNtnCA9bCpKC8MeWlb3k1i4C75gEoZHtY/wnO6LzxEqD3kxrLbKuzkXnUQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-4.9.0.tgz",
+      "integrity": "sha512-DVxn8RvspEgnm2YtyoE3kCZRAzpLM6TQzQdDCw6XyGFVmtbT+YHwrSCHAAv7Vj7joimi4fs6B3GWwP8A1wXF6A==",
       "dependencies": {
         "airbrake-js": "^1.6.8",
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.0.0",
         "immutability-helper": "^3.1.1",
-        "joi": "^17.6.2",
+        "joi": "^17.13.1",
         "lodash": "^4.17.21",
-        "moment": "^2.29.4",
+        "moment": "^2.30.1",
         "moment-range": "^4.0.2",
-        "pg": "^8.8.0",
+        "pg": "^8.11.5",
         "request": "^2.88.2",
         "request-promise-native": "^1.0.9",
         "winston": "^2.4.6"
@@ -2140,11 +2140,11 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dependencies": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -4281,9 +4281,9 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "node_modules/joi": {
-      "version": "17.13.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.0.tgz",
-      "integrity": "sha512-9qcrTyoBmFZRNHeVP4edKqIUEgFzq7MHvTNSDuHSqkpOPtiBkgNgcmTSqmiw1kw9tdKaiddvIDv/eCJDxmqWCA==",
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -4759,9 +4759,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -7511,18 +7511,18 @@
       }
     },
     "@envage/water-abstraction-helpers": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-4.8.3.tgz",
-      "integrity": "sha512-p/pemY1kKT7DPxr7iXY/o/kjvAIWyNtnCA9bCpKC8MeWlb3k1i4C75gEoZHtY/wnO6LzxEqD3kxrLbKuzkXnUQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-4.9.0.tgz",
+      "integrity": "sha512-DVxn8RvspEgnm2YtyoE3kCZRAzpLM6TQzQdDCw6XyGFVmtbT+YHwrSCHAAv7Vj7joimi4fs6B3GWwP8A1wXF6A==",
       "requires": {
         "airbrake-js": "^1.6.8",
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.0.0",
         "immutability-helper": "^3.1.1",
-        "joi": "^17.6.2",
+        "joi": "^17.13.1",
         "lodash": "^4.17.21",
-        "moment": "^2.29.4",
+        "moment": "^2.30.1",
         "moment-range": "^4.0.2",
-        "pg": "^8.8.0",
+        "pg": "^8.11.5",
         "request": "^2.88.2",
         "request-promise-native": "^1.0.9",
         "winston": "^2.4.6"
@@ -9007,11 +9007,11 @@
       }
     },
     "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "requires": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.12"
       }
     },
     "cross-spawn": {
@@ -10630,9 +10630,9 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "joi": {
-      "version": "17.13.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.0.tgz",
-      "integrity": "sha512-9qcrTyoBmFZRNHeVP4edKqIUEgFzq7MHvTNSDuHSqkpOPtiBkgNgcmTSqmiw1kw9tdKaiddvIDv/eCJDxmqWCA==",
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
       "requires": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -11028,9 +11028,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,20 @@
       "version": "2.27.10",
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@envage/hapi-pg-rest-api": "^7.0.0",
+        "@envage/hapi-pg-rest-api": "^7.0.1",
         "@envage/water-abstraction-helpers": "^4.9.0",
         "@hapi/boom": "^9.1.4",
-        "@hapi/hapi": "^21.3.2",
+        "@hapi/hapi": "^21.3.10",
         "blipp": "^4.0.2",
-        "db-migrate": "^0.11.13",
-        "db-migrate-pg": "^1.2.2",
+        "db-migrate": "^0.11.14",
+        "db-migrate-pg": "^1.5.2",
         "dotenv": "^8.6.0",
         "hapi-auth-jwt2": "^8.8.1",
         "hapi-pino": "^11.0.1",
-        "joi": "^17.6.0",
+        "joi": "^17.13.3",
         "map-keys-deep-lodash": "^1.2.4",
-        "moment": "^2.29.4",
-        "pg": "^8.8.0",
+        "moment": "^2.30.1",
+        "pg": "^8.12.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -621,9 +621,9 @@
       }
     },
     "node_modules/@hapi/catbox-memory": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.1.tgz",
-      "integrity": "sha512-sVb+/ZxbZIvaMtJfAbdyY+QJUQg9oKTwamXpEg/5xnfG5WbJLTjvEn4kIGKz9pN3ENNbIL/bIdctmHmqi/AdGA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.2.tgz",
+      "integrity": "sha512-H1l4ugoFW/ZRkqeFrIo8p1rWN0PA4MDTfu4JmcoNDvnY975o29mqoZblqFTotxNHlEkMPpIiIBJTV+Mbi+aF0g==",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
@@ -638,9 +638,9 @@
       }
     },
     "node_modules/@hapi/catbox-memory/node_modules/@hapi/hoek": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.2.tgz",
-      "integrity": "sha512-aKmlCO57XFZ26wso4rJsW4oTUnrgTFw2jh3io7CAtO9w4UltBNwRXvXIVzzyfkaaLRo3nluP/19msA8vDUUuKw=="
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
+      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/catbox/node_modules/@hapi/boom": {
       "version": "10.0.1",
@@ -755,9 +755,9 @@
       "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
     },
     "node_modules/@hapi/hapi": {
-      "version": "21.3.9",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.9.tgz",
-      "integrity": "sha512-AT5m+Rb8iSOFG3zWaiEuTJazf4HDYl5UpRpyxMJ3yR+g8tOEmqDv6FmXrLHShdvDOStAAepHGnr1G7egkFSRdw==",
+      "version": "21.3.10",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.10.tgz",
+      "integrity": "sha512-CmEcmTREW394MaGGKvWpoOK4rG8tKlpZLs30tbaBzhCrhiL2Ti/HARek9w+8Ya4nMBGcd+kDAzvU44OX8Ms0Jg==",
       "dependencies": {
         "@hapi/accept": "^6.0.1",
         "@hapi/ammo": "^6.0.1",
@@ -765,7 +765,7 @@
         "@hapi/bounce": "^3.0.1",
         "@hapi/call": "^9.0.1",
         "@hapi/catbox": "^12.1.1",
-        "@hapi/catbox-memory": "^6.0.1",
+        "@hapi/catbox-memory": "^6.0.2",
         "@hapi/heavy": "^8.0.1",
         "@hapi/hoek": "^11.0.2",
         "@hapi/mimos": "^7.0.1",
@@ -5070,9 +5070,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/pg": {
-      "version": "8.11.5",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.5.tgz",
-      "integrity": "sha512-jqgNHSKL5cbDjFlHyYsCXmQDrfIX/3RsNwYqpd4N0Kt8niLuNoRNH+aazv6cOd43gPh9Y4DjQCtb+X0MH0Hvnw==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
+      "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
       "dependencies": {
         "pg-connection-string": "^2.6.4",
         "pg-pool": "^3.6.2",
@@ -7757,9 +7757,9 @@
       }
     },
     "@hapi/catbox-memory": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.1.tgz",
-      "integrity": "sha512-sVb+/ZxbZIvaMtJfAbdyY+QJUQg9oKTwamXpEg/5xnfG5WbJLTjvEn4kIGKz9pN3ENNbIL/bIdctmHmqi/AdGA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.2.tgz",
+      "integrity": "sha512-H1l4ugoFW/ZRkqeFrIo8p1rWN0PA4MDTfu4JmcoNDvnY975o29mqoZblqFTotxNHlEkMPpIiIBJTV+Mbi+aF0g==",
       "requires": {
         "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
@@ -7774,9 +7774,9 @@
           }
         },
         "@hapi/hoek": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.2.tgz",
-          "integrity": "sha512-aKmlCO57XFZ26wso4rJsW4oTUnrgTFw2jh3io7CAtO9w4UltBNwRXvXIVzzyfkaaLRo3nluP/19msA8vDUUuKw=="
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
+          "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
         }
       }
     },
@@ -7833,9 +7833,9 @@
       "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
     },
     "@hapi/hapi": {
-      "version": "21.3.9",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.9.tgz",
-      "integrity": "sha512-AT5m+Rb8iSOFG3zWaiEuTJazf4HDYl5UpRpyxMJ3yR+g8tOEmqDv6FmXrLHShdvDOStAAepHGnr1G7egkFSRdw==",
+      "version": "21.3.10",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.10.tgz",
+      "integrity": "sha512-CmEcmTREW394MaGGKvWpoOK4rG8tKlpZLs30tbaBzhCrhiL2Ti/HARek9w+8Ya4nMBGcd+kDAzvU44OX8Ms0Jg==",
       "requires": {
         "@hapi/accept": "^6.0.1",
         "@hapi/ammo": "^6.0.1",
@@ -7843,7 +7843,7 @@
         "@hapi/bounce": "^3.0.1",
         "@hapi/call": "^9.0.1",
         "@hapi/catbox": "^12.1.1",
-        "@hapi/catbox-memory": "^6.0.1",
+        "@hapi/catbox-memory": "^6.0.2",
         "@hapi/heavy": "^8.0.1",
         "@hapi/hoek": "^11.0.2",
         "@hapi/mimos": "^7.0.1",
@@ -11245,9 +11245,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "pg": {
-      "version": "8.11.5",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.5.tgz",
-      "integrity": "sha512-jqgNHSKL5cbDjFlHyYsCXmQDrfIX/3RsNwYqpd4N0Kt8niLuNoRNH+aazv6cOd43gPh9Y4DjQCtb+X0MH0Hvnw==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
+      "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
       "requires": {
         "pg-cloudflare": "^1.1.1",
         "pg-connection-string": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -20,20 +20,20 @@
     "version": "npx --yes auto-changelog -p --commit-limit false && git add CHANGELOG.md"
   },
   "dependencies": {
-    "@envage/hapi-pg-rest-api": "^7.0.0",
+    "@envage/hapi-pg-rest-api": "^7.0.1",
     "@envage/water-abstraction-helpers": "^4.9.0",
     "@hapi/boom": "^9.1.4",
-    "@hapi/hapi": "^21.3.2",
+    "@hapi/hapi": "^21.3.10",
     "blipp": "^4.0.2",
-    "db-migrate": "^0.11.13",
-    "db-migrate-pg": "^1.2.2",
+    "db-migrate": "^0.11.14",
+    "db-migrate-pg": "^1.5.2",
     "dotenv": "^8.6.0",
     "hapi-auth-jwt2": "^8.8.1",
     "hapi-pino": "^11.0.1",
-    "joi": "^17.6.0",
+    "joi": "^17.13.3",
     "map-keys-deep-lodash": "^1.2.4",
-    "moment": "^2.29.4",
-    "pg": "^8.8.0",
+    "moment": "^2.30.1",
+    "pg": "^8.12.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@envage/hapi-pg-rest-api": "^7.0.0",
-    "@envage/water-abstraction-helpers": "4.8.3",
+    "@envage/water-abstraction-helpers": "^4.9.0",
     "@hapi/boom": "^9.1.4",
     "@hapi/hapi": "^21.3.2",
     "blipp": "^4.0.2",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4597

Some updates to the packages in the `water-abstraction-helpers` repo were made a while ago in PR https://github.com/DEFRA/water-abstraction-helpers/pull/269

This package isn't currently set to auto-update in the `package.json` for minor/patch version changes to the helpers package. So in this PR, the helpers package will be updated and set to auto-update for minor/patch updates in the future.