### PR TITLE
Add `notes` and `created_by` to `versions` table

### DIFF
--- a/migrations/20250127142444-add-notes-to-versions.js
+++ b/migrations/20250127142444-add-notes-to-versions.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250127142444-add-notes-to-versions-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250127142444-add-notes-to-versions-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250127142444-add-notes-to-versions-down.sql
+++ b/migrations/sqls/20250127142444-add-notes-to-versions-down.sql
@@ -1,0 +1,9 @@
+/* revert changes made */
+
+BEGIN;
+
+ALTER TABLE returns.versions
+  DROP COLUMN notes,
+  DROP COLUMN created_by;
+
+COMMIT;

--- a/migrations/sqls/20250127142444-add-notes-to-versions-up.sql
+++ b/migrations/sqls/20250127142444-add-notes-to-versions-up.sql
@@ -1,0 +1,14 @@
+/*
+  Adds columns to allow us to capture a note and who created the version
+
+  We capture the user_id so we can link to the idm.users record of the user who created the return version and
+  accompanying records
+*/
+
+BEGIN;
+
+ALTER TABLE returns.versions
+  ADD COLUMN notes text,
+  ADD COLUMN created_by integer;
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4807

New functionality is being created to enable the user to save a note against a return submission, previously referred to as a version.

This PR will add the `notes` and `created_by` columns to the `returns.versions` table. A subsequent PR will make similar changes to our views and test data migrations in the system repo.