### PR TITLE
Add sent date column

### DIFF
--- a/migrations/20250425170708-add-sent-date.js
+++ b/migrations/20250425170708-add-sent-date.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250425170708-add-sent-date-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250425170708-add-sent-date-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250425170708-add-sent-date-down.sql
+++ b/migrations/sqls/20250425170708-add-sent-date-down.sql
@@ -1,0 +1,3 @@
+/* revert changes made */
+
+ALTER TABLE "returns"."returns" DROP COLUMN sent_date;

--- a/migrations/sqls/20250425170708-add-sent-date-up.sql
+++ b/migrations/sqls/20250425170708-add-sent-date-up.sql
@@ -1,0 +1,6 @@
+/*
+  Adds sent_date to returns.returns to allow us to import the sent date from the NALD, and set the value ourselves
+  in the future (once we've updated the notifications journey).
+*/
+
+ALTER TABLE "returns"."returns" ADD COLUMN sent_date date;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5018

WRLS is taking over management of the 'returns leg' from NALD. Contingent on that is the ability to continue reporting on returns.

Our work with RDP is behind the service changes, but we need to make the switch soon to support the first quarterly return submissions in July. So, we will ensure we can generate the same reports by building ad hoc queries.

We've spotted that the existing BOXI reports include `send_date`. This is something the [water-abstraction-import](https://github.com/DEFRA/water-abstraction-import) doesn't currently import from NALD, but could with a minor change. However, the first step is to add a migration to add a field to the `returns.returns` table.