### PR TITLE
Fix "Build Status" badge

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Water Abstraction Returns
 
-![Build Status](https://github.com/DEFRA/water-abstraction-returns/workflows/CI/badge.svg?branch=main)
+![Build Status](https://github.com/DEFRA/water-abstraction-returns/actions/workflows/ci.yml/badge.svg?branch=main)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_water-abstraction-returns&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_water-abstraction-returns)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_water-abstraction-returns&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_water-abstraction-returns)
 [![Known Vulnerabilities](https://snyk.io/test/github/DEFRA/water-abstraction-returns/badge.svg)](https://snyk.io/test/github/DEFRA/water-abstraction-returns)
@@ -8,7 +8,7 @@
 
 The water-abstraction-returns service is a evolving solution to initially handle the returns required by water abstraction licences.
 
-The service is developed in HAPI/NodeJS and backed by a Postgres SQL database.  All data is transferred via a REST API with JWT authentication.
+The service is developed in HAPI/NodeJS and backed by a Postgres SQL database. All data is transferred via a REST API with JWT authentication.
 
 ## Development Team
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/135

The url used for GitHub's CI badges has changed, leading to our existing badge not displaying correctly. This PR fixes this.