### PR TITLE
Change user id for imported return submissions

### DIFF
--- a/migrations/20250515080834-change-rtn-version-user-id.js
+++ b/migrations/20250515080834-change-rtn-version-user-id.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250515080834-change-rtn-version-user-id-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250515080834-change-rtn-version-user-id-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250515080834-change-rtn-version-user-id-down.sql
+++ b/migrations/sqls/20250515080834-change-rtn-version-user-id-down.sql
@@ -1,0 +1,2 @@
+
+UPDATE "returns".versions SET user_id = 'imported@from.nald' WHERE user_id = 'imported.from@nald.gov.uk';

--- a/migrations/sqls/20250515080834-change-rtn-version-user-id-up.sql
+++ b/migrations/sqls/20250515080834-change-rtn-version-user-id-up.sql
@@ -1,0 +1,15 @@
+/*
+  Change user id for imported return submissions
+
+  https://eaflood.atlassian.net/browse/WATER-5053
+
+  Unfortunately, the email assigned to the historic NALD return submissions we import from NALD is causing problems for
+  the legacy code that generates the return cycles report.
+
+  It believes that `imported@from.nald` is an invalid email address, so it is throwing an error when reading the
+  submission records.
+
+  We've found that it is happy if we change the email to `imported.from@nald.gov.uk`, so this data fix does that.
+*/
+
+UPDATE "returns".versions SET user_id = 'imported.from@nald.gov.uk' WHERE user_id = 'imported@from.nald';


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5053

Unfortunately, the email assigned to the historic NALD return submissions we import from NALD is causing problems for the legacy code that generates the return cycles report.

It believes that `imported@from.nald` is an invalid email address, so it is throwing an error when reading the submission records.

We've found that it is happy if we change the email to `imported.from@nald.gov.uk`, so this data fix does that.