### PR TITLE
Fix missing received date in return log

### DIFF
--- a/migrations/20250624113147-fix-missing-received-date.js
+++ b/migrations/20250624113147-fix-missing-received-date.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250624113147-fix-missing-received-date-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250624113147-fix-missing-received-date-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250624113147-fix-missing-received-date-down.sql
+++ b/migrations/sqls/20250624113147-fix-missing-received-date-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+/* No down script due to migration being used to correct missing data */

--- a/migrations/sqls/20250624113147-fix-missing-received-date-up.sql
+++ b/migrations/sqls/20250624113147-fix-missing-received-date-up.sql
@@ -1,0 +1,16 @@
+/*
+  Fix missing received date in return log
+
+  https://eaflood.atlassian.net/browse/WATER-5075
+
+  Whilst working on creating a new 'clean' empty VOID return logs job we found an edge case in the data.
+
+  One of the return logs has submitted returns data but its `received_date` is missing.
+
+  We believe this is a residual record that was effected by the issue in WATER-5057. There was a point that the timings
+  of the FME WRLS to NALD and the FME/WRLS NALD to WRLS imports were out of sync which led to return logs getting their
+  `received_date` blanked.
+
+  To fix it, the dates needed to be manually re-entered into NALD and this one just appears to have been missed
+*/
+UPDATE "returns"."returns" SET received_date = '2025-05-09' WHERE "returns".return_id = 'v1:7:TH/039/0039/030/R02:10064887:2024-10-30:2025-03-31';


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5075

Whilst working on creating a new 'clean' empty VOID return logs job, we found an edge case in the data.

One of the return logs has submitted returns data, but its `received_date` is missing.

We believe this is a residual record that was affected by the issue in WATER-5057. There was a point that the timings of the 'FME WRLS to NALD' and the 'FME/WRLS NALD to WRLS' imports were out of sync, which led to return logs getting their `received_date` blanked.

To fix it, the dates needed to be manually re-entered into NALD, and this one appears to have been missed.
