### PR TITLE
Fix corrupt return log for a licence pt2

### DIFF
--- a/migrations/20250711142942-fix-corrupt-return-log-pt2.js
+++ b/migrations/20250711142942-fix-corrupt-return-log-pt2.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250711142942-fix-corrupt-return-log-pt2-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250711142942-fix-corrupt-return-log-pt2-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250711142942-fix-corrupt-return-log-pt2-down.sql
+++ b/migrations/sqls/20250711142942-fix-corrupt-return-log-pt2-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+/* No down script due to migration being used to correct incorrect data */

--- a/migrations/sqls/20250711142942-fix-corrupt-return-log-pt2-up.sql
+++ b/migrations/sqls/20250711142942-fix-corrupt-return-log-pt2-up.sql
@@ -1,0 +1,31 @@
+/*
+  Fix corrupt return log for a licence pt2
+
+  https://eaflood.atlassian.net/browse/WATER-5137
+
+  The business reported that when viewing the return logs for a licence, the UI was not making sense.
+
+  One was showing as received when it is not actually due yet. Another was showing as 'due' in November, but when you
+  click into it, there is submission data.
+
+  They were correct that the data was incorrect for these return logs. The source of the confusion was multiple NALD
+  return logs for the same period. This is not a scenario the import was designed to handle, and from discussions, it
+  appears to be an exception in NALD.
+
+  This means the import has pulled data from multiple sources when trying to set up the single return log in WRLS.
+
+  The returns import is now disabled as WRLS has taken over management of all returns from NALD. So, the only solution
+  is a data fix migration for this licence.
+
+  We thought we had nailed this with [Fix corrupt return logs for a
+  licence](https://github.com/DEFRA/water-abstraction-returns/pull/430). But we'd overlooked the implications of running
+  [Data fix submitted rtn logs missing received date](https://github.com/DEFRA/water-abstraction-returns/pull/429).
+
+  It's script will see the return submission, and no `received_date` against the return log. So it sets the status to
+  `completed` and the `received_date`.
+
+  Then our fix for corrupt logs comes along and deletes the errant return submission. Knowing now it comes after, it
+  also needs to reset the status to `due` and the received date to 'null'.
+*/
+
+UPDATE "returns"."returns" r SET "status" = 'due', received_date = null WHERE r.return_id = 'v1:2:03/28/73/0013:10064890:2024-11-01:2025-10-31';


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5137

The business reported that when viewing the return logs for a licence, the UI was not making sense.

One was showing as received when it is not actually due yet. Another was showing as 'due' in November, but when you click into it, there is submission data.

They were correct that the data was incorrect for these return logs. The source of the confusion was multiple NALD return logs for the same period. This is not a scenario the import was designed to handle, and from discussions, it appears to be an exception in NALD.

This means the import has pulled data from multiple sources when trying to set up the single return log in WRLS.

The returns import is now disabled as WRLS has taken over management of all returns from NALD. So, the only solution is a data fix migration for this licence.

We thought we had nailed this with [Fix corrupt return logs for a licence](https://github.com/DEFRA/water-abstraction-returns/pull/430). But we'd overlooked the implications of running [Data fix submitted rtn logs missing received date](https://github.com/DEFRA/water-abstraction-returns/pull/429).

It's script will see the return submission, and no `received_date` against the return log. So it sets the status to `completed` and the `received_date`.

Then our fix for corrupt logs comes along and deletes the errant return submission. Knowing now it comes after, it also needs to reset the status to `due` and the received date to 'null'.