### PR TITLE
Switch to using Snyk CLI action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,40 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-COOKIE-8163060:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T16:13:33.632Z
+        created: 2025-08-06T16:13:33.635Z
+  SNYK-JS-JSONWEBTOKEN-3180022:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T16:14:00.524Z
+        created: 2025-08-06T16:14:00.528Z
+  SNYK-JS-JSONWEBTOKEN-3180024:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T16:15:33.348Z
+        created: 2025-08-06T16:15:33.354Z
+  SNYK-JS-JSONWEBTOKEN-3180026:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T16:16:17.745Z
+        created: 2025-08-06T16:16:17.751Z
+  SNYK-JS-FORMDATA-10841150:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-05T16:16:56.866Z
+        created: 2025-08-06T16:16:56.872Z
+  SNYK-JS-REQUEST-3361831:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-05T16:17:21.461Z
+        created: 2025-08-06T16:17:21.468Z
+  SNYK-JS-TOUGHCOOKIE-5672873:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-05T16:17:50.495Z
+        created: 2025-08-06T16:17:50.512Z
+patch: {}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5191

With the adoption of SSO in the Defra GitHub org, our current [Snyk](https://snyk.io) status checks have stopped working.

The [team issue](https://github.com/DEFRA/water-abstraction-team/issues/144) goes into more detail, but in essence, whilst the GitHub account that **Snyk** uses to connect has SSO enabled, it won't connect to GitHub to update the PR with the test result.

This change performs the same check without **Snyk** having to authenticate to GitHub. Instead, GitHub will authenticate with **Snyk** by using its CLI via a GitHub action.

It does mean **Snyk** will no longer be listed as a separate check; instead, it will just be a new step in our CI. So, the outcome (adding a package with a vulnerability will cause the PR to fail checks) will be the same.