### PR TITLE
Return cycle table allow null due date

### DIFF
--- a/migrations/20250903080247-return-cycle-null-due-date.js
+++ b/migrations/20250903080247-return-cycle-null-due-date.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250903080247-return-cycle-null-due-date-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250903080247-return-cycle-null-due-date-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250903080247-return-cycle-null-due-date-down.sql
+++ b/migrations/sqls/20250903080247-return-cycle-null-due-date-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE returns.return_cycles ALTER COLUMN due_date SET NOT NULL;

--- a/migrations/sqls/20250903080247-return-cycle-null-due-date-up.sql
+++ b/migrations/sqls/20250903080247-return-cycle-null-due-date-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE returns.return_cycles ALTER COLUMN due_date DROP NOT NULL;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5212

As part of our work to get ready for new regulations we need to leave the due date out of the return logs when created. As this due date will be set after the users have been notified we no longer need to have a due date on a return cycle. 

This PR updates the database column to set it to null.