### PR TITLE
Fix return logs updated_at timestamp

### DIFF
--- a/migrations/20250918183216-correct-updated-at.js
+++ b/migrations/20250918183216-correct-updated-at.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250918183216-correct-updated-at-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250918183216-correct-updated-at-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250918183216-correct-updated-at-down.sql
+++ b/migrations/sqls/20250918183216-correct-updated-at-down.sql
@@ -1,0 +1,1 @@
+/* No down script due to migration being used to correct incorrect data */

--- a/migrations/sqls/20250918183216-correct-updated-at-up.sql
+++ b/migrations/sqls/20250918183216-correct-updated-at-up.sql
@@ -1,0 +1,24 @@
+/*
+  Fix return logs updated_at timestamp
+
+  https://eaflood.atlassian.net/browse/WATER-5256
+
+  The business reported that the return logs updated_at timestamp was not being updated when a return was submitted.
+
+  The bug has now been fixed, but we are left with some return log records that have an incorrect updated_at timestamp.
+
+  This migration will fix this issue by updating the return logs updated_at timestamp to match the created_at timestamp
+  of the current version of the return log, but only if the updated_at timestamp is earlier than the created_at
+  timestamp of the current version. This will prevent legitimate updated_at timestamps from being overwritten.
+*/
+
+WITH current_returns AS (
+	SELECT v.return_id, v.created_at
+	FROM "returns".versions v
+	WHERE v."current" = true
+)
+UPDATE "returns"."returns" r
+SET updated_at = cr.created_at
+FROM current_returns cr
+WHERE r.return_id = cr.return_id
+AND r.updated_at < cr.created_at;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5256

The business reported that the return logs `updated_at` timestamp was not being updated when a return was submitted.

The bug has now been fixed, but we are left with some return log records that have an incorrect `updated_at` timestamp.

This migration will fix this issue by updating the return logs `updated_at` timestamp to match the `created_at` timestamp of the current version of the return log, but only if the `updated_at` timestamp is earlier than the `created_at` timestamp of the current version. This will prevent legitimate `updated_at` timestamps from being overwritten.