### PR TITLE
Remove lines for nil returns

### DIFF
--- a/migrations/20250923105541-remove-nil-return-lines.js
+++ b/migrations/20250923105541-remove-nil-return-lines.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250923105541-remove-nil-return-lines-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250923105541-remove-nil-return-lines-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250923105541-remove-nil-return-lines-down.sql
+++ b/migrations/sqls/20250923105541-remove-nil-return-lines-down.sql
@@ -1,0 +1,1 @@
+/* No down script due to migration being used to correct incorrect data */

--- a/migrations/sqls/20250923105541-remove-nil-return-lines-up.sql
+++ b/migrations/sqls/20250923105541-remove-nil-return-lines-up.sql
@@ -1,0 +1,15 @@
+/*
+  Remove lines for nil returns
+
+  https://eaflood.atlassian.net/browse/WATER-5278
+
+  A bug has been reported by the business that when a return is submitted as a nil return, return lines are incorrectly
+  being created. This bug has now been fixed, but we are left with some return lines that should not be there.
+
+  This migration will remove any return lines that may exist for nil returns.
+*/
+
+DELETE FROM "returns".lines l
+USING "returns".versions v
+WHERE v.version_id = l.version_id
+  AND v.nil_return = true;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5278

A bug has been reported by the business that when a return is submitted as a nil return, return lines are incorrectly being created. This bug has now been fixed, but we are left with some return lines that should not be there.

This migration will remove any return lines that may exist for nil returns.