### PR TITLE
Set returns with blank lines to nil returns

### DIFF
--- a/migrations/20250929144920-flag-as-nil-returns.js
+++ b/migrations/20250929144920-flag-as-nil-returns.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250929144920-flag-as-nil-returns-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250929144920-flag-as-nil-returns-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250929144920-flag-as-nil-returns-down.sql
+++ b/migrations/sqls/20250929144920-flag-as-nil-returns-down.sql
@@ -1,0 +1,1 @@
+/* No down script due to migration being used to correct incorrect data */

--- a/migrations/sqls/20250929144920-flag-as-nil-returns-up.sql
+++ b/migrations/sqls/20250929144920-flag-as-nil-returns-up.sql
@@ -1,0 +1,34 @@
+/*
+  Set returns with blank lines to nil returns
+
+  https://eaflood.atlassian.net/browse/WATER-5192
+
+  There was an issue with the return submission process that meant that some returns were being submitted with blank
+  return lines when they weren't supposed to be. This migration will set those returns to be nil returns and remove the
+  blank return submission lines.
+*/
+
+BEGIN;
+
+-- Step 1: Find all return versions that are not currently marked as nil returns but have no lines with a quantity
+WITH not_nil_with_blank_lines AS (
+	SELECT v.version_id
+  FROM "returns".versions v
+  LEFT JOIN "returns".lines l
+    ON v.version_id = l.version_id AND l.quantity IS NOT NULL
+  WHERE l.version_id IS null
+  AND v.nil_return = false
+)
+-- Step 2: Update those return versions to be nil returns
+UPDATE "returns".versions v
+SET nil_return = true
+FROM not_nil_with_blank_lines nn
+WHERE v.version_id = nn.version_id;
+
+-- Step 3: Remove any lines associated with those now nil returns
+DELETE FROM "returns".lines l
+USING "returns".versions v
+WHERE v.version_id = l.version_id
+AND v.nil_return = true;
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5192

There was an issue with the return submission process that meant that some returns were being submitted with blank return lines when they weren't supposed to be. This migration will set those returns to be nil returns and remove the blank return submission lines.