### PR TITLE
Fix failing test

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -19,6 +19,7 @@ module.exports = {
     'Response',
     'Headers',
     'Request',
-    'Symbol(undici.globalDispatcher.1)'
+    'Symbol(undici.globalDispatcher.1)',
+    'Symbol(undici.globalDispatcher.2)'
   ].join(',')
 };


### PR DESCRIPTION
## Fix failing test run caused by undici global dispatcher leak

### The problem

`npm test` recently started failing with exit code `1`, appearing to fail on the test:

> `Check versions API › when creating a new version for the same return › does not set current to false if the same version is saved`

The console showed a `duplicate key value violates unique constraint "unique_version"` error, which made it look like the test itself was broken.

### Root cause

The test assertions were never actually failing. All 59 tests pass (✔), including the one above.

Two things were going on:

1. **The `duplicate key` error is expected/intended noise.** That test deliberately re-saves a version using the *same* `version_number`. The unique constraint on `(return_id, version_number)` correctly rejects the duplicate, which is exactly what proves the original version keeps `current = true`. The error is only logged, not thrown to the test.

2. **The real failure was a global leak.** `lab` exits non-zero when it detects an unrecognised global. It was flagging `Symbol(undici.globalDispatcher.2)`.

This is Node.js's built-in undici (used by global `fetch`), not a project dependency. A Node/undici update bumped undici's internal global-dispatcher API version from `1` to `2`, so it now registers `Symbol(undici.globalDispatcher.2)` on `globalThis`. Our leak allowlist in .labrc.js only whitelisted `Symbol(undici.globalDispatcher.1)`, so the newer symbol was reported as a leak and failed the run. Confirmed under Node v24.18.0.

### The fix

Added `Symbol(undici.globalDispatcher.2)` to the `globals` allowlist in .labrc.js, keeping `.1` in place for older Node versions. No application/test code changes were needed — the returns code was never at fault.

After the change, the full test suite passes with exit code `0`.